### PR TITLE
Tabs in sidebar

### DIFF
--- a/addon/components/flexberry-tab-bar.js
+++ b/addon/components/flexberry-tab-bar.js
@@ -1,0 +1,95 @@
+import Ember from 'ember';
+import layout from '../templates/components/flexberry-tab-bar';
+
+/**
+ * FlexberryTabBarComponent
+ * Component to display semantic ui tabs
+ * @extends Ember.Component
+ */
+export default Ember.Component.extend({
+  classNames: ['flexberry-tab-bar'],
+
+  layout,
+
+  /**
+   * Contains items to display in tab bar 
+   * @property items
+   * @type {Array}
+   * @default []
+   * @example items: [{selector: 'tab1', caption: 'Tab one', active: true }, {selector: 'tab2', caption: 'Tab two'}]
+   * @desc the first item with active=true will be set as active
+   * @desc if no active items provided, the first one will be active by default
+   */
+  items: [],
+
+  tabs: Ember.computed('items', 'items.[]', function () {
+    let active = false;
+    let items = this.get('items') || [];
+    let result = [];
+    items.forEach((item) => {
+      if (Ember.get(item, 'active') && Ember.get(item, 'active') === true) {
+        if (active) {
+          Ember.set(item, 'active', false);
+        } else {
+          Ember.set(item, 'class', 'active');
+          active = true;
+        }
+      }
+      result.push(item);
+    });
+
+    if (!active && result.length > 0) {
+      Ember.set(result[0], 'active', true);
+    }
+
+    return result;
+  }),
+
+  /**
+   * @property prevTab
+   */
+  prevTab: undefined,
+
+  target: undefined,
+
+  uicontext: undefined,
+
+  actions: {
+    onTabClick(currentTab) {
+      let prevTab = this.get('prevTab');
+      let changed = false;
+      if (prevTab !== currentTab) {
+        this.set('prevTab', currentTab);
+        changed = true;
+      }
+      if (changed) {
+        this.sendAction('onTabClick', this.get('target'), this.get('uicontext'));
+      }
+    }
+  },
+  /**
+      Initializes component's DOM-related properties.
+    */
+  didInsertElement() {
+    this._super(...arguments);
+
+    this.$('.tabular.menu .item').tab();
+  },
+
+  /**
+    Handles DOM-related component's properties after each render.
+  */
+  didRender() {
+    this._super(...arguments);
+    // Initialize possibly added new tabs.
+    this.$('.tabular.menu .item').tab();
+  },
+
+  /**
+    Deinitializes component's DOM-related properties.
+  */
+  willDestroyElement() {
+    this._super(...arguments);
+    this.$('.tabular.menu .item').tab('destroy');
+  }
+});

--- a/addon/components/flexberry-tab-bar.js
+++ b/addon/components/flexberry-tab-bar.js
@@ -68,7 +68,7 @@ export default Ember.Component.extend({
           let itemClass = Ember.get(item, 'class') || '';
 
           active = true;
-          itemClass += itemClass + 'active';
+          itemClass += itemClass + ' active';
           Ember.set(item, 'class', itemClass);
         }
       }

--- a/addon/components/flexberry-tab-bar.js
+++ b/addon/components/flexberry-tab-bar.js
@@ -40,7 +40,7 @@ export default Ember.Component.extend({
   flexberryClassNames,
 
   /**
-   * Contains items to display in tab bar 
+   * Contains items to display in tab bar
    * @property items
    * @type {Array}
    * @default []
@@ -72,6 +72,7 @@ export default Ember.Component.extend({
           Ember.set(item, 'class', itemClass);
         }
       }
+
       result.push(item);
     });
 

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -5,6 +5,7 @@
 @import './components/flexberry-search-panel';
 @import './components/flexberry-spatial-bookmarks';
 @import './components/flexberry-tree';
+@import './components/flexberry-tab-bar';
 @import './components/layer-result-list';
 @import './components/map-commands-dialogs/search';
 @import './components/map-commands-dialogs/go-to';

--- a/addon/styles/components/flexberry-spatial-bookmarks.scss
+++ b/addon/styles/components/flexberry-spatial-bookmarks.scss
@@ -1,38 +1,41 @@
 .bookmark-block {
-    padding: 5px 10px;
+  padding: 0.75em 1em;
 }
 
 .bookmarks {
-    width: 100%;
-    padding-top: 10px;
+  width: 100%;
+  padding-top: 10px;
 }
 
 .bmrk-add-block {
-    margin-top: 10px;
+  margin-top: 10px;
 }
 
-.bookmark-item, .bmrk-add-block {
-    width: 100%;
-    position: relative;    
-    margin-bottom: 5px;
+.bookmark-item,
+.bmrk-add-block {
+  width: 100%;
+  position: relative;
+  margin-bottom: 5px;
 }
 
 .bookmark-item {
-    border-bottom:1px solid #E8E9E9;
+  border-bottom: 1px solid #E8E9E9;
 }
 
 .bookmark-item:hover {
-    background-color: #F3F3F3;
+  background-color: #F3F3F3;
 }
 
-.bookmark-item-title, .bmrk-add-block .flexberry-textbox {
-    width: 100%;
-    padding-right: 90px;
-    line-height: 36px;
+.bookmark-item-title,
+.bmrk-add-block .flexberry-textbox {
+  width: 100%;
+  padding-right: 90px;
+  line-height: 36px;
 }
 
-.bookmark-item-buttons, .bmrk-add-block-buttons {
-    position: absolute;
-    right: 0;
-    top: 0;
+.bookmark-item-buttons,
+.bmrk-add-block-buttons {
+  position: absolute;
+  right: 0;
+  top: 0;
 }

--- a/addon/styles/components/flexberry-tab-bar.scss
+++ b/addon/styles/components/flexberry-tab-bar.scss
@@ -1,0 +1,7 @@
+  .flexberry-tab-bar {
+    float: right;
+  }
+
+  .ui.right.sidebar.tabbar {
+    background: #fff;
+  }

--- a/addon/templates/components/flexberry-tab-bar.hbs
+++ b/addon/templates/components/flexberry-tab-bar.hbs
@@ -1,7 +1,12 @@
-<div class="ui top attached tabular menu">
+<div class="ui tabular menu">
   {{#each tabs as |item|}}
-    <a class="{{concat "tab" " " "item" " " item.class}}" data-tab="{{item.selector}}" {{action "onTabClick" item.selector on="click"}}>
-      {{item.caption}}
+    <a class="{{concat flexberryClassNames.tab " " "tab" " " "item" " " item.class}}" title="{{item.caption}}" data-tab="{{item.selector}}" {{action "onTabClick" item.selector on="click"}}>
+      {{#if item.iconClass}}
+        <i class="{{concat flexberryClassNames.tabIcon " " item.iconClass}}"></i>
+      {{/if}}
+      {{#if (not item.iconClass)}}
+        {{item.caption}}
+      {{/if}}
     </a>
   {{/each}}
 </div>

--- a/addon/templates/components/flexberry-tab-bar.hbs
+++ b/addon/templates/components/flexberry-tab-bar.hbs
@@ -1,0 +1,7 @@
+<div class="ui top attached tabular menu">
+  {{#each tabs as |item|}}
+    <a class="{{concat "tab" " " "item" " " item.class}}" data-tab="{{item.selector}}" {{action "onTabClick" item.selector on="click"}}>
+      {{item.caption}}
+    </a>
+  {{/each}}
+</div>

--- a/addon/templates/components/flexberry-tab-bar.hbs
+++ b/addon/templates/components/flexberry-tab-bar.hbs
@@ -1,12 +1,12 @@
-<div class="ui tabular menu">
-  {{#each tabs as |item|}}
-    <a class="{{concat flexberryClassNames.tab " " "tab" " " "item" " " item.class}}" title="{{item.caption}}" data-tab="{{item.selector}}" {{action "onTabClick" item.selector on="click"}}>
-      {{#if item.iconClass}}
-        <i class="{{concat flexberryClassNames.tabIcon " " item.iconClass}}"></i>
-      {{/if}}
-      {{#if (not item.iconClass)}}
-        {{item.caption}}
-      {{/if}}
-    </a>
-  {{/each}}
-</div>
+{{#each tabs as |item|}}
+  <a class="{{concat flexberryClassNames.tab " " "tab" " " "item" " " item.class}}"
+    title="{{item.caption}}"
+    data-tab="{{item.selector}}"
+    {{action "change" item.selector on="click"}}>
+    {{#if item._hasIcon}}
+      <i class="{{concat flexberryClassNames.tabIcon " " item.iconClass}}"></i>
+    {{else}}
+      {{item.caption}}
+    {{/if}}
+  </a>
+{{/each}}

--- a/app/components/flexberry-tab-bar.js
+++ b/app/components/flexberry-tab-bar.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-flexberry-gis/components/flexberry-tab-bar';

--- a/tests/dummy/app/controllers/map.js
+++ b/tests/dummy/app/controllers/map.js
@@ -82,21 +82,24 @@ export default EditMapController.extend(
     /**
      * items
      */
-    sidebarItems: [{
-        selector: 'treeview',
-        caption: 'Дерево',
-        iconClass: 'list icon'
-      },
-      {
-        selector: 'search',
-        caption: 'Поиск',
-        iconClass: 'search icon'
-      },
-      {
-        selector: 'bookmarks',
-        caption: 'Закладки',
-        iconClass: 'bookmark icon'
-      }
-    ]
+    sidebarItems: Ember.computed(function () {
+      let i18n = this.get('i18n');
 
+      return [{
+          selector: 'treeview',
+          caption: i18n.t('forms.map.treeviewbuttontooltip').toString(),
+          iconClass: 'list icon'
+        },
+        {
+          selector: 'search',
+          caption: i18n.t('forms.map.searchbuttontooltip').toString(),
+          iconClass: 'search icon'
+        },
+        {
+          selector: 'bookmarks',
+          caption: i18n.t('forms.map.bookmarksbuttontooltip').toString(),
+          iconClass: 'bookmark icon'
+        }
+      ];
+    })
   });

--- a/tests/dummy/app/controllers/map.js
+++ b/tests/dummy/app/controllers/map.js
@@ -16,7 +16,7 @@ import EditFormControllerOperationsIndicationMixin from '../mixins/edit-form-con
 export default EditMapController.extend(
   EditFormControllerOperationsIndicationMixin, {
 
-    availableCRS: Ember.computed(function() {
+    availableCRS: Ember.computed(function () {
       let availableModes = Ember.A();
       let i18n = this.get('i18n');
       availableModes.push({
@@ -37,6 +37,17 @@ export default EditMapController.extend(
 
     actions: {
       toggleSidebar(sidebar, context) {
+        Ember.$(sidebar)
+          .sidebar({
+            context: Ember.$(context),
+            dimPage: false,
+            closable: false
+          })
+          .sidebar('setting', 'transition', 'overlay')
+          .sidebar('toggle');
+      },
+
+      onTabChange(sidebar, context) {
         Ember.$(sidebar)
           .sidebar({
             context: Ember.$(context),
@@ -78,6 +89,24 @@ export default EditMapController.extend(
       @type String
       @default 'maps'
     */
-    parentRoute: 'maps'
+    parentRoute: 'maps',
+
+    /**
+     * items
+     */
+    sidebarItems: [{
+        selector: 'treeview',
+        caption: 'Дерево',
+        active: true
+      },
+      {
+        selector: 'search',
+        caption: 'Поиск'
+      },
+      {
+        selector: 'bookmarks',
+        caption: 'Закладки'
+      }
+    ]
 
   });

--- a/tests/dummy/app/controllers/map.js
+++ b/tests/dummy/app/controllers/map.js
@@ -46,18 +46,6 @@ export default EditMapController.extend(
           .sidebar('setting', 'transition', 'overlay')
           .sidebar('toggle');
       },
-
-      onTabChange(sidebar, context) {
-        Ember.$(sidebar)
-          .sidebar({
-            context: Ember.$(context),
-            dimPage: false,
-            closable: false
-          })
-          .sidebar('setting', 'transition', 'overlay')
-          .sidebar('toggle');
-      },
-
       querySearch(queryString) {
         let leafletMap = this.get('leafletMap');
         let e = {
@@ -97,15 +85,17 @@ export default EditMapController.extend(
     sidebarItems: [{
         selector: 'treeview',
         caption: 'Дерево',
-        active: true
+        iconClass: 'list icon'
       },
       {
         selector: 'search',
-        caption: 'Поиск'
+        caption: 'Поиск',
+        iconClass: 'search icon'
       },
       {
         selector: 'bookmarks',
-        caption: 'Закладки'
+        caption: 'Закладки',
+        iconClass: 'bookmark icon'
       }
     ]
 

--- a/tests/dummy/app/controllers/map.js
+++ b/tests/dummy/app/controllers/map.js
@@ -36,16 +36,19 @@ export default EditMapController.extend(
     }),
 
     actions: {
-      toggleSidebar(sidebar, context) {
-        Ember.$(sidebar)
-          .sidebar({
-            context: Ember.$(context),
-            dimPage: false,
-            closable: false
-          })
-          .sidebar('setting', 'transition', 'overlay')
-          .sidebar('toggle');
+      toggleSidebar(sidebar, context, e) {
+        if (!e.changed) {
+          Ember.$(sidebar)
+            .sidebar({
+              context: Ember.$(context),
+              dimPage: false,
+              closable: false
+            })
+            .sidebar('setting', 'transition', 'overlay')
+            .sidebar('toggle');
+        }
       },
+
       querySearch(queryString) {
         let leafletMap = this.get('leafletMap');
         let e = {

--- a/tests/dummy/app/templates/map.hbs
+++ b/tests/dummy/app/templates/map.hbs
@@ -41,12 +41,7 @@
     </div>
   </div>
   <div class="ui inernally celled grid">
-    {{flexberry-tab-bar
-      onTabClick=(action "onTabChange")
-      items=sidebarItems
-      target="ui.very.wide.right.sidebar.pushable"
-      uicontext='.mappanel'}}
-    <div class="ui very wide right sidebar pushable">
+    <div class="ui very wide right sidebar pushable tabbar">
       <div data-tab="treeview" class="ui tab treeview">
           {{flexberry-maplayers
             class="styled"
@@ -123,13 +118,11 @@
           {{map-tools/measure activate=(action "onMapToolActivate" target=mapToolbar)}}
           {{map-tools/draw activate=(action "onMapToolActivate" target=mapToolbar)}}
           {{map-commands/export execute=(action "onMapCommandExecute" target=mapToolbar)}}
-          
-          <a {{action 'toggleSidebar' '.ui.sidebar.right' '.mappanel'}}
-              class="icon item"
-              title={{t "forms.map.treeviewbuttontooltip"}}>
-            <i class="list icon"></i>
-          </a>        
-          {{/flexberry-maptoolbar}}
+        {{/flexberry-maptoolbar}}
+        {{flexberry-tab-bar
+          onTabClick=(action 'toggleSidebar' '.ui.sidebar.right' '.mappanel')
+          items=sidebarItems
+        }}
       </div>
     </div>
     <div class="row mappanel">

--- a/tests/dummy/app/templates/map.hbs
+++ b/tests/dummy/app/templates/map.hbs
@@ -41,58 +41,65 @@
     </div>
   </div>
   <div class="ui inernally celled grid">
-    <div class="ui very wide right sidebar treeview pushable">
-        {{flexberry-maplayers
-          class="styled"
-          cswConnections=cswConnections
-          leafletMap=leafletMap
-          layers=(get-with-dynamic-actions this "model.hierarchy"
-            hierarchyPropertyName="layers"
-            pathKeyword="layerPath"
-            dynamicActions=(array
-              (hash
-                on="add"
-                actionName="onMapLayerAdd"
-                actionArguments=(array "{% layerPath %}")
-              )
-              (hash
-                on="edit"
-                actionName="onMapLayerEdit"
-                actionArguments=(array "{% layerPath %}")
-              )
-              (hash
-                on="remove"
-                actionName="onMapLayerRemove"
-                actionArguments=(array "{% layerPath %}")
-              )
-              (hash
-                on="changeVisibility"
-                actionName="onMapLayerChangeVisibility"
-                actionArguments=(array "{% layerPath %}.visibility")
+    {{flexberry-tab-bar
+      onTabClick=(action "onTabChange")
+      items=sidebarItems
+      target="ui.very.wide.right.sidebar.pushable"
+      uicontext='.mappanel'}}
+    <div class="ui very wide right sidebar pushable">
+      <div data-tab="treeview" class="ui tab treeview">
+          {{flexberry-maplayers
+            class="styled"
+            cswConnections=cswConnections
+            leafletMap=leafletMap
+            layers=(get-with-dynamic-actions this "model.hierarchy"
+              hierarchyPropertyName="layers"
+              pathKeyword="layerPath"
+              dynamicActions=(array
+                (hash
+                  on="add"
+                  actionName="onMapLayerAdd"
+                  actionArguments=(array "{% layerPath %}")
+                )
+                (hash
+                  on="edit"
+                  actionName="onMapLayerEdit"
+                  actionArguments=(array "{% layerPath %}")
+                )
+                (hash
+                  on="remove"
+                  actionName="onMapLayerRemove"
+                  actionArguments=(array "{% layerPath %}")
+                )
+                (hash
+                  on="changeVisibility"
+                  actionName="onMapLayerChangeVisibility"
+                  actionArguments=(array "{% layerPath %}.visibility")
+                )
               )
             )
-          )
-        add=(action "onMapLayerAdd" "model.hierarchy")
-      }}
-    </div>
-    <div class="ui very wide right sidebar search pushable">
-      {{flexberry-search-panel
-          querySearch=(action "querySearch")
-          clearSearch=(action "clearSearch")
-          searchInProcess=searchInProcess
-          searchSettings=(flexberry-search-properties-osm-ru "http://openstreetmap.ru/api/autocomplete?q={query}")
-          }}
-      {{layer-result-list
-        results=searchResults
-        serviceLayer=serviceLayer
-        leafletMap=leafletMap
+          add=(action "onMapLayerAdd" "model.hierarchy")
         }}
-    </div>
-    <div class="ui very wide right sidebar bookmarks pushable">
-      {{spatial-bookmark        
-        leafletMap=leafletMap
-        mapid=model.id
-      }}
+      </div>
+      <div data-tab="search" class="ui tab search">
+        {{flexberry-search-panel
+            querySearch=(action "querySearch")
+            clearSearch=(action "clearSearch")
+            searchInProcess=searchInProcess
+            searchSettings=(flexberry-search-properties-osm-ru "http://openstreetmap.ru/api/autocomplete?q={query}")
+            }}
+        {{layer-result-list
+          results=searchResults
+          serviceLayer=serviceLayer
+          leafletMap=leafletMap
+          }}
+      </div>
+      <div data-tab="bookmarks" class="ui tab bookmarks">
+        {{spatial-bookmark        
+          leafletMap=leafletMap
+          mapid=model.id
+        }}
+      </div>
     </div>
     <div class="row">
       <div class="sixteen wide column">
@@ -116,22 +123,13 @@
           {{map-tools/measure activate=(action "onMapToolActivate" target=mapToolbar)}}
           {{map-tools/draw activate=(action "onMapToolActivate" target=mapToolbar)}}
           {{map-commands/export execute=(action "onMapCommandExecute" target=mapToolbar)}}
-          <a {{action 'toggleSidebar' '.ui.sidebar.bookmarks' '.mappanel'}}
-              class="icon item"
-              title={{t "forms.map.bookmarksbuttontooltip"}}>
-            <i class="bookmark icon"></i>
-          </a>
-          <a {{action 'toggleSidebar' '.ui.sidebar.treeview' '.mappanel'}}
+          
+          <a {{action 'toggleSidebar' '.ui.sidebar.right' '.mappanel'}}
               class="icon item"
               title={{t "forms.map.treeviewbuttontooltip"}}>
             <i class="list icon"></i>
-          </a>
-          <a {{action 'toggleSidebar' '.ui.sidebar.search' '.mappanel'}}
-              class="icon item"
-              title={{t "forms.map.searchbuttontooltip"}}>
-            <i class="search icon"></i>
-          </a>
-        {{/flexberry-maptoolbar}}
+          </a>        
+          {{/flexberry-maptoolbar}}
       </div>
     </div>
     <div class="row mappanel">

--- a/tests/dummy/app/templates/map.hbs
+++ b/tests/dummy/app/templates/map.hbs
@@ -78,16 +78,16 @@
       </div>
       <div data-tab="search" class="ui tab search">
         {{flexberry-search-panel
-            querySearch=(action "querySearch")
-            clearSearch=(action "clearSearch")
-            searchInProcess=searchInProcess
-            searchSettings=(flexberry-search-properties-osm-ru "http://openstreetmap.ru/api/autocomplete?q={query}")
-            }}
+          querySearch=(action "querySearch")
+          clearSearch=(action "clearSearch")
+          searchInProcess=searchInProcess
+          searchSettings=(flexberry-search-properties-osm-ru "http://openstreetmap.ru/api/autocomplete?q={query}")
+        }}
         {{layer-result-list
           results=searchResults
           serviceLayer=serviceLayer
           leafletMap=leafletMap
-          }}
+        }}
       </div>
       <div data-tab="bookmarks" class="ui tab bookmarks">
         {{spatial-bookmark        

--- a/tests/dummy/app/templates/map.hbs
+++ b/tests/dummy/app/templates/map.hbs
@@ -120,7 +120,7 @@
           {{map-commands/export execute=(action "onMapCommandExecute" target=mapToolbar)}}
         {{/flexberry-maptoolbar}}
         {{flexberry-tab-bar
-          onTabClick=(action 'toggleSidebar' '.ui.sidebar.right' '.mappanel')
+          change=(action 'toggleSidebar' '.ui.sidebar.right' '.mappanel')
           items=sidebarItems
         }}
       </div>


### PR DESCRIPTION
Added new component flexberry-tab-bar, that controls tab switching with semantic UI tabs
Logic is quite simple: pass the list of items (caption, selector, additional classes) and add to tabs 'data-tab' attribute. So now in dummy treeview, search and bookmarks placed in one sidebar and are switchable with tab component.
Name of branch does not really corresponds the task because it was supposed to move identify tool results in sidebar there, but it seems to be huge task and will be done in a separate branch.
