### PR TITLE
Identify tab improvements

### DIFF
--- a/addon/components/flexberry-identify-panel.js
+++ b/addon/components/flexberry-identify-panel.js
@@ -419,6 +419,7 @@ let FlexberryIdentifyPanelComponent = Ember.Component.extend({
 
   /**
    * @method _switch
+   * handles changes in layer and tools options and fires 'flexberry-map:identificationOptionChanged' event
    * @private
    */
   _switch(_switchActiveLayer, _switchActiveTool) {
@@ -429,7 +430,7 @@ let FlexberryIdentifyPanelComponent = Ember.Component.extend({
       this._switchActiveLayer(layer);
     }
 
-    if (_switchActiveLayer) {
+    if (_switchActiveTool) {
       this._switchActiveTool(tool);
     }
 

--- a/addon/components/flexberry-identify-panel.js
+++ b/addon/components/flexberry-identify-panel.js
@@ -382,7 +382,6 @@ let FlexberryIdentifyPanelComponent = Ember.Component.extend({
     this.sendAction('onIdentificationFinished', e);
   },
 
-
   /**
     Initializes DOM-related component's properties.
   */
@@ -429,6 +428,7 @@ let FlexberryIdentifyPanelComponent = Ember.Component.extend({
     if (_switchActiveLayer) {
       this._switchActiveLayer(layer);
     }
+
     if (_switchActiveLayer) {
       this._switchActiveTool(tool);
     }
@@ -439,7 +439,9 @@ let FlexberryIdentifyPanelComponent = Ember.Component.extend({
     }
 
     let mapToolName = 'identify-' + layer + '-' + tool;
-    leafletMap.fire('flexberry-map:identificationOptionChanged', { mapToolName });
+    leafletMap.fire('flexberry-map:identificationOptionChanged', {
+      mapToolName
+    });
   },
 
   /**

--- a/addon/components/flexberry-maptoolbar.js
+++ b/addon/components/flexberry-maptoolbar.js
@@ -246,24 +246,8 @@ let FlexberryMaptoolbarComponent = Ember.Component.extend({
       return;
     }
 
-    // Attach custom event-handler.
-    leafletMap.on('flexberry-map:identificationFinished', this.identificationFinished, this);
-
     this._activateDefaultMapTool();
   })),
-
-  /**
-    Handles 'flexberry-map:identificationFinished' event of leaflet map.
-
-    @method identificationFinished
-    @param {Object} e Event object.
-    @param {Object} results Hash containing search results.
-    @param {Object[]} results.features Array containing (GeoJSON feature-objects)[http://geojson.org/geojson-spec.html#feature-objects]
-    or a promise returning such array.
-  */
-  identificationFinished(e) {
-    this.sendAction('onIdentificationFinished', e);
-  },
 
   /**
     Destroys component.

--- a/addon/components/layer-result-list.js
+++ b/addon/components/layer-result-list.js
@@ -78,8 +78,12 @@ export default Ember.Component.extend({
 
   actions: {
     /**
-      Set selected feature and add its layer to serviceLayer on map
-      @method actions.selectFeature
+        Handles inner FeatureResultItem's bubbled 'selectFeature' action.
+        Invokes component's {{#crossLink "FeatureResultItem/sendingActions.selectFeature:method"}}'selectFeature'{{/crossLink}} action.
+
+        @method actions.selectFeature
+        @param {Object} feature
+        which describes inner FeatureResultItem's 'selectFeature' feature object.
     */
     selectFeature(feature) {
       let selectedFeature = this.get('_selectedFeature');
@@ -230,10 +234,5 @@ export default Ember.Component.extend({
       this.set('_noData', displayResults.length === 0);
       this.set('_showLoader', false);
     });
-  }),
-
-  didInsertElement() {
-    this._super(...arguments);
-    Ember.$('.layer-result-item').accordion();
-  }
+  })
 });

--- a/addon/components/layer-result-list.js
+++ b/addon/components/layer-result-list.js
@@ -98,6 +98,7 @@ export default Ember.Component.extend({
               serviceLayer.removeLayer(selectedFeature.leafletLayer);
             }
           }
+
           if (Ember.isArray(feature)) {
             feature.forEach((item) => this._selectFeature(item));
           } else {

--- a/addon/components/map-tools/identify.js
+++ b/addon/components/map-tools/identify.js
@@ -67,6 +67,15 @@ let IdentifyMapToolComponent = Ember.Component.extend({
   tagName: '',
 
   /**
+    Leaflet map.
+
+    @property leafletMap
+    @type <a href="http://leafletjs.com/reference-1.0.0.html#map">L.Map</a>
+    @default null
+  */
+  leafletMap: null,
+
+  /**
     Map tool's additional CSS-class.
 
     @property class
@@ -117,22 +126,6 @@ let IdentifyMapToolComponent = Ember.Component.extend({
   toolMode: '',
 
   /**
-    Flag: indicates whether map tool should be enabled after it's re-render
-    @property enableOnRerender
-    @default true
-    @type {Boolean}
-  */
-  enableOnRerender: true,
-
-  /**
-    Flag: indicates whether map tool should be enabled after it's re-render
-    @property _enableOnRerender
-    @default true
-    @type {Boolean}
-  */
-  _enableOnRerender: true,
-
-  /**
     Contains formatted tool name with layers options
     @property _toolName
     @type {String}
@@ -148,12 +141,6 @@ let IdentifyMapToolComponent = Ember.Component.extend({
     } else {
       return 'identify';
     }
-  }),
-
-  _shouldRerenderObserver: Ember.observer('_toolName', 'enableOnRerender', function () {
-    let layerMode = this.get('layerMode');
-    let toolMode = this.get('toolMode');
-    this.set('_enableOnRerender', this.get('enableOnRerender') === true && !(Ember.isBlank(layerMode) || Ember.isBlank(toolMode)));
   }),
 
   actions: {
@@ -185,16 +172,6 @@ let IdentifyMapToolComponent = Ember.Component.extend({
     if (!toolMode) {
       this.set('toolMode', 'rectangle');
     }
-  },
-
-  /**
-    Handles DOM-related component's properties after each render.
-  */
-  didRender() {
-    this._super(...arguments);
-
-    // set this flag to false to force re-render next time with _shouldRerenderObserver
-    this.set('_enableOnRerender', false);
   },
 
   /**

--- a/addon/helpers/regex-test.js
+++ b/addon/helpers/regex-test.js
@@ -5,8 +5,8 @@
 import Ember from 'ember';
 
 /**
-  Array contains helper.
-  Checks whether the specified item contains in the given array or not.
+  Regex tester helper.
+  Checks whether the specified item matching provided regex expression
 
   @class RegexTestHelper
   @extends <a href="http://emberjs.com/api/classes/Ember.Helper.html">Ember.Helper</a>

--- a/addon/locales/en/components/feature-result-item.js
+++ b/addon/locales/en/components/feature-result-item.js
@@ -2,6 +2,7 @@ export default {
   'show-info-caption': 'Show info',
   'zoom-to-caption': 'Zoom to',
   'pan-to-caption': 'Pan to',
+  'select-all-caption': 'Select all',
   'feature-table-property-name': 'Property name',
   'feature-table-property-value': 'Value'
 };

--- a/addon/locales/en/components/map-tools.js
+++ b/addon/locales/en/components/map-tools.js
@@ -28,6 +28,9 @@ export default {
     },
     'polygon': {
       'caption': 'Polygon'
+    },
+    'clear': {
+      'caption': 'Clear'
     }
   },
   'measure': {

--- a/addon/locales/ru/components/feature-result-item.js
+++ b/addon/locales/ru/components/feature-result-item.js
@@ -2,6 +2,7 @@ export default {
   'show-info-caption': 'Показать информацию',
   'zoom-to-caption': 'Приблизить',
   'pan-to-caption': 'Центрировать',
+  'select-all-caption': 'Выбрать все',
   'feature-table-property-name': 'Поле',
   'feature-table-property-value': 'Значение'
 };

--- a/addon/locales/ru/components/map-tools.js
+++ b/addon/locales/ru/components/map-tools.js
@@ -28,6 +28,9 @@ export default {
     },
     'polygon': {
       'caption': 'Полигон'
+    },
+    'clear': {
+      'caption': 'Очистить'
     }
   },
   'measure': {

--- a/addon/styles/components/layer-result-list.scss
+++ b/addon/styles/components/layer-result-list.scss
@@ -7,12 +7,26 @@
       border-radius: 2px;
     }
   }
-  .feature-result-item-group.icon.item {
-    position: absolute;
-    left: 1.2em;
-    margin-top: .5em;
+  .feature-result-item {
+    &-select.icon.item {
+      position: absolute;
+      left: 1.2em;
+      margin-top: .5em;
+    }
+    &-title {
+      &>* {
+        vertical-align: top;
+        display: inline-block;
+      }
+    }
+    &-caption {
+      text-overflow: ellipsis;
+      max-width: 80%;
+    }
   }
-  .flexberry-toggler .title .flexberry-toggler-caption {
-    margin-left: 1em;
+  &-toggler .title {
+    .flexberry-toggler-caption {
+      margin-left: 1em;
+    }
   }
 }

--- a/addon/styles/components/layer-result-list.scss
+++ b/addon/styles/components/layer-result-list.scss
@@ -7,4 +7,12 @@
       border-radius: 2px;
     }
   }
+  .feature-result-item-group.icon.item {
+    position: absolute;
+    left: 1.2em;
+    margin-top: .5em;
+  }
+  .flexberry-toggler .title .flexberry-toggler-caption {
+    margin-left: 1em;
+  }
 }

--- a/addon/templates/components/feature-result-item.hbs
+++ b/addon/templates/components/feature-result-item.hbs
@@ -1,16 +1,20 @@
 <div class="item {{if (eq feature selectedFeature) 'active'}}">
-  <a class="icon item" title="{{t "components.feature-result-item.show-info-caption"}}" {{action "showInfo"}}>
-    <i class="caret {{if infoExpanded 'down' 'right'}} icon"></i>
-  </a>
-  <a class="icon item" title="{{t "components.feature-result-item.zoom-to-caption"}}" {{action "zoomTo"}}>
-    <i class="marker icon"></i>
-  </a>
-  <a class="icon item" title="{{t "components.feature-result-item.pan-to-caption"}}" {{action "panTo"}}>
-    <i class="hand paper icon"></i>
-  </a>
-  <span {{action "selectFeature" on="click" }} {{action "zoomTo" on="doubleClick" }}>
-      {{get feature.properties _displayProperty}}
-  </span>
+  <div class="feature-result-item-title" {{action "showInfo"}}>
+    <div class="feature-result-item-toolbar">
+      <a class="icon item" title="{{t "components.feature-result-item.show-info-caption"}}">
+        <i class="caret {{if _infoExpanded 'down' 'right'}} icon"></i>
+      </a>
+      <a class="icon item" title="{{t "components.feature-result-item.zoom-to-caption"}}" {{action "zoomTo"}}>
+        <i class="marker icon"></i>
+      </a>
+      <a class="icon item" title="{{t "components.feature-result-item.pan-to-caption"}}" {{action "panTo"}}>
+        <i class="hand paper icon"></i>
+      </a>
+    </div>
+    <div class="feature-result-item-caption">
+        {{get feature.properties _displayProperty}}
+    </div>
+  </div>
   {{#if _infoExpanded}}
     <table class="ui compact celled table">
       <tr>

--- a/addon/templates/components/flexberry-identify-panel.hbs
+++ b/addon/templates/components/flexberry-identify-panel.hbs
@@ -45,8 +45,9 @@
     </div>
     <div class="{{concat "ui four wide column" flexberryClassName.otherOptions}}">
         {{flexberry-button
-            class="ui icon button"
-            iconClass="remove icon"
+            class=(concat flexberryClassNames.clearButton " " clearClass)
+            iconClass=clearIconClass
+            tooltip=clearCaption
             click=(action "clear")
         }}
     </div>

--- a/addon/templates/components/layer-result-list.hbs
+++ b/addon/templates/components/layer-result-list.hbs
@@ -1,9 +1,14 @@
 {{#if _showLoader}}
-  <div class="ui active  inline loader"></div>{{t "components.layer-result-list.processing"}}
+  <div class="ui active inline loader"></div>{{t "components.layer-result-list.processing"}}
 {{else if _noData}}
   {{t "components.layer-result-list.nodata"}}
 {{/if}}
 {{#each _displayResults as |result|}}
+  <a class="feature-result-item-group icon item"
+    title="{{t "components.feature-result-item.select-all-caption"}}"
+    {{action "selectFeature" result.features}}>
+    <i class="marker icon"></i>
+  </a>
    {{#flexberry-toggler caption=result.name expanded=result.first}}    
      <div class="ui list transition">
       {{#each result.features as |feature|}}

--- a/addon/templates/components/layer-result-list.hbs
+++ b/addon/templates/components/layer-result-list.hbs
@@ -4,23 +4,25 @@
   {{t "components.layer-result-list.nodata"}}
 {{/if}}
 {{#each _displayResults as |result|}}
-  <a class="feature-result-item-group icon item"
-    title="{{t "components.feature-result-item.select-all-caption"}}"
-    {{action "selectFeature" result.features}}>
-    <i class="marker icon"></i>
-  </a>
-   {{#flexberry-toggler caption=result.name expanded=result.first}}    
-     <div class="ui list transition">
-      {{#each result.features as |feature|}}
-        {{feature-result-item
-          feature=feature
-          displaySettings=result.settings
-          selectedFeature=_selectedFeature
-          selectFeature=(action "selectFeature")
-          panTo=(action "panTo")
-          zoomTo=(action "zoomTo")
-        }}
-      {{/each}}
-     </div>
-    {{/flexberry-toggler}}
+  <div class="feature-result-item-group">
+    <a class="feature-result-item-select icon item"
+      title="{{t "components.feature-result-item.select-all-caption"}}"
+      {{action "selectFeature" result.features}}>
+      <i class="marker icon"></i>
+    </a>
+    {{#flexberry-toggler caption=result.name expanded=result.first class='layer-result-list-toggler'}}    
+      <div class="ui list transition">
+        {{#each result.features as |feature|}}
+          {{feature-result-item
+            feature=feature
+            displaySettings=result.settings
+            selectedFeature=_selectedFeature
+            selectFeature=(action "selectFeature")
+            panTo=(action "panTo")
+            zoomTo=(action "zoomTo")
+          }}
+        {{/each}}
+      </div>
+      {{/flexberry-toggler}}
+  </div>
 {{/each}}

--- a/addon/templates/components/map-tools/identify.hbs
+++ b/addon/templates/components/map-tools/identify.hbs
@@ -5,5 +5,5 @@
   tooltip=tooltip
   iconClass=iconClass
   activate=(action "onMapToolActivate")
-  enableOnRerender=enableOnRerender
+  leafletMap=leafletMap
 }}

--- a/tests/dummy/app/controllers/map.js
+++ b/tests/dummy/app/controllers/map.js
@@ -21,7 +21,7 @@ export default EditMapController.extend(
       @type String
       @default ''
      */
-    identifyLayersOption: '',
+    identifyLayersOption: 'visible',
 
     /**
       Parameter contains current map identification tool option (arrow, square, polygon etc.)
@@ -29,25 +29,11 @@ export default EditMapController.extend(
       @type String
       @default ''
      */
-    identifyToolOption: '',
-
-    /**
-      Parameter contains default map identification layer option (all, visible, top etc.)
-      @property _defaultIdentifyLayersOption
-      @type String
-      @default 'visible'
-     */
-    _defaultIdentifyLayersOption: 'visible',
-
-    /**
-      Parameter contains default map identification tool option (arrow, square, polygon etc.)
-      @property _defaultIdentifyToolOption
-      @type String
-      @default 'rectangle'
-     */
-    _defaultIdentifyToolOption: 'rectangle',
+    identifyToolOption: 'rectangle',
 
     serviceLayer: null,
+
+    boundingBoxLayer: null,
 
     /**
       Parent route.
@@ -131,16 +117,20 @@ export default EditMapController.extend(
             })
             .sidebar('setting', 'transition', 'overlay')
             .sidebar('toggle');
-
-          if (e.tabName === 'identify') {
-            if (Ember.isBlank(this.get('identifyLayersOption'))) {
-              this.set('identifyLayersOption', this.get('_defaultIdentifyLayersOption'));
-            }
-
-            if (Ember.isBlank(this.get('identifyToolOption'))) {
-              this.set('identifyToolOption', this.get('_defaultIdentifyToolOption'));
-            }
+        }
+        if (e.tabName === 'identify') {
+          let leafletMap = this.get('leafletMap');
+          if (Ember.isNone(leafletMap)) {
+            return;
           }
+
+          let layer = this.get('identifyLayersOption');
+          let tool = this.get('identifyToolOption');
+
+          let mapToolName = 'identify-' + layer + '-' + tool;
+          leafletMap.fire('flexberry-map:identificationOptionChanged', {
+            mapToolName
+          });
         }
       },
 
@@ -169,10 +159,21 @@ export default EditMapController.extend(
 
       clearIdentification() {
         this.set('identifyResults', null);
+
+        let serviceLayer = this.get('serviceLayer');
+        if (serviceLayer) {
+          serviceLayer.clearLayers();
+        }
+
+        let boundingBoxLayer = this.get('boundingBoxLayer');
+        if (boundingBoxLayer) {
+          boundingBoxLayer.disableEdit();
+          boundingBoxLayer.remove();
+        }
       },
 
       /**
-          Handles 'flexberry-maptoolbar:identificationFinished' event of leaflet map.
+          Handles 'flexberry-identify-panel:identificationFinished' event of leaflet map.
 
           @method identificationFinished
           @param {Object} e Event object.
@@ -189,6 +190,7 @@ export default EditMapController.extend(
           serviceLayer.clearLayers();
         }
 
+        this.set('boundingBoxLayer', e.relatedLayer);
         this.set('identifyResults', e.results);
 
         // below is kind of madness, but if you want sidebar to move on identification finish - do that

--- a/tests/dummy/app/controllers/map.js
+++ b/tests/dummy/app/controllers/map.js
@@ -118,6 +118,7 @@ export default EditMapController.extend(
             .sidebar('setting', 'transition', 'overlay')
             .sidebar('toggle');
         }
+
         if (e.tabName === 'identify') {
           let leafletMap = this.get('leafletMap');
           if (Ember.isNone(leafletMap)) {

--- a/tests/dummy/app/templates/map.hbs
+++ b/tests/dummy/app/templates/map.hbs
@@ -96,8 +96,10 @@
       </div>
       <div data-tab="identify" class="ui tab identify">
         {{flexberry-identify-panel
+          leafletMap=leafletMap
           layerMode=identifyLayersOption
           toolMode=identifyToolOption
+          identificationFinished=(action 'onIdentificationFinished')
           clear=(action 'clearIdentification')
         }}
         {{layer-result-list
@@ -116,7 +118,6 @@
     <div class="row">
       <div class="sixteen wide column">
         {{#flexberry-maptoolbar
-          identificationFinished=(action 'onIdentificationFinished')
           leafletMap=leafletMap
           layers=model.hierarchy as |mapToolbar|
         }}
@@ -127,6 +128,7 @@
             activate=(action "onMapToolActivate" target=mapToolbar)
             layerMode=identifyLayersOption
             toolMode=identifyToolOption
+            leafletMap=leafletMap
           }}
           {{map-commands/go-to
             availableCRS=availableCRS


### PR DESCRIPTION
Fixed all remarks since identify-panel branch PR
About Sergey's remark №5
"Похоже что при выводе результатов не учитываются настройки идентификации внутри слоев (задал для слоя точек displayProperty: “name”, но в списке найденных объектов их имена не отобразились, возможно и с локализацией имен свойств, и с другими настройками есть та же проблема)."
kuzkok (pradostev) told, that further we will make searchSettings and identifySetting equal, so now layer-result-list take displayProperties from searchSettings, that it is way it happens
remark №4
"При выполнении идентификации интерфейс сайдбара не блокируется, возможно стоит это делать, хотя я на этом не настаиваю."
I think it is just UI sugar, so it could be done on applied stage of development