### PR TITLE
Fixed query method for wfs layers

### DIFF
--- a/addon/components/layers/wfs-layer.js
+++ b/addon/components/layers/wfs-layer.js
@@ -208,21 +208,32 @@ export default BaseLayer.extend({
     Handles 'flexberry-map:query' event of leaflet map.
 
     @method _query
+    @param {Object[]} layerLinks Array containing metadata for query
     @param {Object} e Event object.
     @param {Object} queryFilter Object with query filter paramteres
     @param {Object[]} results.features Array containing leaflet layers objects
     or a promise returning such array.
   */
-  query(e) {
+  query(layerLinks, e) {
     let filter = new L.Filter.EQ();
+    let queryFilter = e.queryFilter;
 
-    for (var property in e.queryFilter) {
-      if (e.queryFilter.hasOwnProperty(property)) {
-        filter.append(property, e.queryFilter[property]);
+    layerLinks.forEach((link) => {
+      let linkParameters = link.get('linkParameter');
+
+      if (Ember.isArray(linkParameters) && linkParameters.length > 0) {
+        linkParameters.forEach(linkParam => {
+          let property = linkParam.get('layerField');
+          let propertyValue = queryFilter[linkParam.get('queryKey')];
+
+          filter.append(property, propertyValue);
+        });
       }
-    }
+    });
 
-    let featuresPromise = this._getFeature({ filter }, true);
+    let featuresPromise = this._getFeature({
+      filter
+    });
 
     return featuresPromise;
   }

--- a/addon/components/layers/wms-wfs-layer.js
+++ b/addon/components/layers/wms-wfs-layer.js
@@ -46,12 +46,13 @@ export default WmsLayerComponent.extend({
     Handles 'flexberry-map:query' event of leaflet map.
 
     @method _query
+    @param {Object[]} layerLinks Array containing metadata for query
     @param {Object} e Event object.
     @param {Object} queryFilter Object with query filter paramteres
     @param {Object[]} results.features Array containing leaflet layers objects
     or a promise returning such array.
   */
-  query(e) {
+  query(layerLinks, e) {
     let innerWfsLayer = this.get('_wfsLayer');
     if (!Ember.isNone(innerWfsLayer)) {
       return innerWfsLayer.query.apply(innerWfsLayer, arguments);


### PR DESCRIPTION
Fixed logic after all the improvements made for 0.1.0 version. Since beta, it had not been written well, according to metadata structure. So, now it is.
It is a feature for RGIS and Gorvodokanal projects, where WFS layers are used.

P.S: fixed one of #92 