### PR TITLE
Integration of Leaflet-WMS plugin

### DIFF
--- a/addon/components/layers-dialogs/settings/wms-single-tile.js
+++ b/addon/components/layers-dialogs/settings/wms-single-tile.js
@@ -52,14 +52,7 @@ export default Ember.Component.extend({
     this._super(...arguments);
 
     // Initialize available info formats.
-    this.set('_availableInfoFormats', Ember.A([
-      'application/geojson',
-      'application/json',
-      'application/vnd.ogc.gml',
-      'application/vnd.ogc.gml/3.1.1',
-      'application/vnd.ogc.wms_xml',
-      'text/plain',
-      'text/html'
-    ]));
+    let availableFormats = L.TileLayer.WMS.Format.getExisting();
+    this.set('_availableInfoFormats', Ember.A(availableFormats));
   }
 });

--- a/addon/components/layers-dialogs/settings/wms-single-tile.js
+++ b/addon/components/layers-dialogs/settings/wms-single-tile.js
@@ -2,39 +2,28 @@
   @module ember-flexberry-gis
 */
 
-import Ember from 'ember';
+import WmsLayerSettingsComponent from './wms';
 import layout from '../../../templates/components/layers-dialogs/settings/wms-single-tile';
+
+// Regular expression used to derive whether settings' url is correct.
+let urlRegex = '(https?|ftp)://(-\.)?([^\s/?\.#-]+\.?)+(/[^\s]*)?';
 
 /**
   Settings-part of WMS single tile layer modal dialog.
 
   @class WmsSingleTileLayerSettingsComponent
-  @extends <a href="http://emberjs.com/api/classes/Ember.Component.html">Ember.Component</a>
+  @extends WmsLayerSettingsComponent
 */
-export default Ember.Component.extend({
+export default WmsLayerSettingsComponent.extend({
   /**
-    Array containing available info formats.
-
-    @property _availableInfoFormats
-    @type String[]
-    @private
+    Reference to component's url regex.
   */
-  _availableInfoFormats: null,
+  urlRegex,
 
   /**
     Reference to component's template.
   */
   layout,
-
-  /**
-    Overridden ['tagName'](http://emberjs.com/api/classes/Ember.Component.html#property_tagName)
-    is empty to disable component's wrapping <div>.
-
-    @property tagName
-    @type String
-    @default ''
-  */
-  tagName: '',
 
   /**
     Editing layer deserialized type-related settings.
@@ -43,16 +32,5 @@ export default Ember.Component.extend({
     @type Object
     @default null
   */
-  settings: null,
-
-  /**
-    Initializes component.
-  */
-  init() {
-    this._super(...arguments);
-
-    // Initialize available info formats.
-    let availableFormats = L.TileLayer.WMS.Format.getExisting();
-    this.set('_availableInfoFormats', Ember.A(availableFormats));
-  }
+  settings: null
 });

--- a/addon/components/layers/wms-layer.js
+++ b/addon/components/layers/wms-layer.js
@@ -37,14 +37,12 @@ export default TileLayer.extend({
     return new Ember.RSVP.Promise((resolve, reject) => {
       layer.getFeatureInfo({
         latlng: latlng,
-        done: function(featuresCollection, xhr) {
+        done(featuresCollection, xhr) {
           let features = Ember.A(Ember.get(featuresCollection, 'features') || []);
           resolve(features);
         },
-        fail: function(errorThrown, xhr) {
+        fail(errorThrown, xhr) {
           reject(errorThrown);
-        },
-        always: function() {
         }
       });
     });
@@ -58,7 +56,7 @@ export default TileLayer.extend({
     Leaflet layer or promise returning such layer.
   */
   createLayer() {
-    return new L.TileLayer.WMS(this.get('url'), this.get('options'));
+    return L.tileLayer.wms(this.get('url'), this.get('options'));
   },
 
   /**

--- a/addon/components/layers/wms-layer.js
+++ b/addon/components/layers/wms-layer.js
@@ -27,63 +27,25 @@ export default TileLayer.extend({
   */
   _getFeatureInfo(latlng) {
     let layer = this.get('_leafletObject');
+
     if (Ember.isNone(layer)) {
       return new Ember.RSVP.Promise((resolve, reject) => {
         reject(`Leaflet layer for '${this.get('layerModel.name')}' isn't created yet`);
       });
     }
 
-    let leafletMap = this.get('leafletMap');
-    let point = leafletMap.latLngToContainerPoint(latlng, leafletMap.getZoom());
-    let size = leafletMap.getSize();
-    let crs = layer.options.crs;
-
-    let mapBounds = leafletMap.getBounds();
-    let sw = crs.project(mapBounds.getSouthWest());
-    let ne = crs.project(mapBounds.getNorthEast());
-
-    let params = {
-      request: 'GetFeatureInfo',
-      service: 'WMS',
-      srs: crs.code,
-      styles: layer.wmsParams.styles,
-      transparent: layer.wmsParams.transparent,
-      version: layer.wmsParams.version,
-      format: layer.wmsParams.format,
-      bbox: sw.x + ',' + sw.y + ',' + ne.x + ',' + ne.y,
-      height: size.y,
-      width: size.x,
-      layers: layer.wmsParams.layers,
-      query_layers: layer.wmsParams.layers,
-      info_format: layer.wmsParams.info_format
-    };
-
-    params[params.version === '1.3.0' ? 'i' : 'x'] = point.x;
-    params[params.version === '1.3.0' ? 'j' : 'y'] = point.y;
-
-    let requestUrl = layer._url + L.Util.getParamString(params, layer._url, true);
     return new Ember.RSVP.Promise((resolve, reject) => {
-      Ember.$.ajax(requestUrl, {
-        dataType: 'text'
-      }).done((data, textStatus, jqXHR) => {
-        let supportedInfoFormats = ['application/geojson', 'application/json'];
-        if (supportedInfoFormats.indexOf(layer.wmsParams.info_format) < 0) {
-          reject(new Error('Format \'' + layer.wmsParams.info_format + '\' isn\'t supported'));
+      layer.getFeatureInfo({
+        latlng: latlng,
+        done: function(featuresCollection, xhr) {
+          let features = Ember.A(Ember.get(featuresCollection, 'features') || []);
+          resolve(features);
+        },
+        fail: function(errorThrown, xhr) {
+          reject(errorThrown);
+        },
+        always: function() {
         }
-
-        let featureCollection = {};
-        try {
-          featureCollection = JSON.parse(jqXHR.responseText);
-        } catch (parseError) {
-          reject(parseError);
-        }
-
-        this.injectLeafletLayersIntoGeoJSON(featureCollection);
-
-        let features = Ember.A(Ember.get(featureCollection, 'features') || []);
-        resolve(features);
-      }).fail((jqXHR, textStatus, errorThrown) => {
-        reject(errorThrown);
       });
     });
   },
@@ -96,7 +58,7 @@ export default TileLayer.extend({
     Leaflet layer or promise returning such layer.
   */
   createLayer() {
-    return L.tileLayer.wms(this.get('url'), this.get('options'));
+    return new L.TileLayer.WMS(this.get('url'), this.get('options'));
   },
 
   /**

--- a/addon/components/layers/wms-layer.js
+++ b/addon/components/layers/wms-layer.js
@@ -37,6 +37,10 @@ export default TileLayer.extend({
     return new Ember.RSVP.Promise((resolve, reject) => {
       layer.getFeatureInfo({
         latlng: latlng,
+        infoFormat: this.get('info_format'),
+        map: this.get('leafletMap'),
+        crs: this.get('crs'),
+        featureCount: this.get('feature_count'),
         done(featuresCollection, xhr) {
           let features = Ember.A(Ember.get(featuresCollection, 'features') || []);
           resolve(features);

--- a/addon/components/layers/wms-single-tile-layer.js
+++ b/addon/components/layers/wms-single-tile-layer.js
@@ -4,81 +4,99 @@
 
 import Ember from 'ember';
 import WmsLayerComponent from './wms-layer';
+import TileLayerComponent from './tile-layer';
 
 /**
   WMS single tile layer component for leaflet map.
 
   @class WMSSingleTileLayerComponent
-  @extends WMSLayerComponent
+  @extends TileLayerComponent
  */
-export default WmsLayerComponent.extend({
+export default TileLayerComponent.extend({
+  leafletOptions: [
+    'minZoom', 'maxZoom', 'maxNativeZoom', 'tileSize', 'subdomains',
+    'errorTileUrl', 'attribution', 'tms', 'continuousWorld', 'noWrap',
+    'zoomOffset', 'zoomReverse', 'opacity', 'zIndex', 'unloadInvisibleTiles',
+    'updateWhenIdle', 'detectRetina', 'reuseTiles', 'bounds',
+    'layers', 'styles', 'format', 'transparent', 'version', 'crs', 'info_format', 'tiled'
+  ],
+
   /**
-    Performs 'getFeatureInfo' request to WMS-service related to layer.
+    Inner WMS layer.
+    Needed for identification (always invisible, won't be added to map).
 
-    @param {<a href="http://leafletjs.com/reference-1.0.0.html#latlng">L.LatLng</a>} latlng Identification point coordinates.
+    @property _wmsLayer
   */
-  _getFeatureInfo(latlng) {
-    let layer = this.get('_leafletObject');
+  _wmsLayer: null,
 
-    if (Ember.isNone(layer)) {
-      return new Ember.RSVP.Promise((resolve, reject) => {
-        reject(`Leaflet layer for '${this.get('layerModel.name')}' isn't created yet`);
-      });
+  /**
+    Handles 'flexberry-map:identify' event of leaflet map.
+
+    @method identify
+    @param {Object} e Event object.
+    @param {<a href="http://leafletjs.com/reference-1.0.0.html#latlngbounds">L.LatLngBounds</a>} options.boundingBox Bounds of identification area.
+    @param {<a href="http://leafletjs.com/reference-1.0.0.html#latlng">L.LatLng</a>} e.latlng Center of the bounding box.
+    @param {Object[]} layers Objects describing those layers which must be identified.
+    @param {Object[]} results Objects describing identification results.
+    Every result-object has the following structure: { layer: ..., features: [...] },
+    where 'layer' is metadata of layer related to identification result, features is array
+    containing (GeoJSON feature-objects)[http://geojson.org/geojson-spec.html#feature-objects]
+    or a promise returning such array.
+  */
+  identify(e) {
+    let innerWmsLayer = this.get('_wmsLayer');
+    if (!Ember.isNone(innerWmsLayer)) {
+      return innerWmsLayer.identify.apply(innerWmsLayer, arguments);
     }
+  },
 
-    let leafletMap = this.get('leafletMap');
-    let point = leafletMap.latLngToContainerPoint(latlng, leafletMap.getZoom());
-    let size = leafletMap.getSize();
-    let crs = layer.options.crs;
+  /**
+    Initializes component.
+  */
+  init() {
+    this._super(...arguments);
 
-    let mapBounds = leafletMap.getBounds();
-    let sw = crs.project(mapBounds.getSouthWest());
-    let ne = crs.project(mapBounds.getNorthEast());
-
-    let params = {
-      request: 'GetFeatureInfo',
-      service: 'WMS',
-      srs: crs.code,
-      styles: layer.wmsParams.styles,
-      transparent: layer.wmsParams.transparent,
-      version: layer.wmsParams.version,
-      format: layer.wmsParams.format,
-      bbox: sw.x + ',' + sw.y + ',' + ne.x + ',' + ne.y,
-      height: size.y,
-      width: size.x,
-      layers: layer.wmsParams.layers,
-      query_layers: layer.wmsParams.layers,
-      info_format: layer.wmsParams.info_format
+    let innerWmsLayerProperties = {
+      leafletMap: this.get('leafletMap'),
+      leafletContainer: this.get('leafletContainer'),
+      layerModel: this.get('layerModel'),
+      index: this.get('index'),
+      visibility: false,
+      crs: this.get('crs'),
+      url: this.get('url'),
+      layers: this.get('layers'),
+      info_format: this.get('info_format'),
+      feature_count: this.get('feature_count')
     };
 
-    params[params.version === '1.3.0' ? 'i' : 'x'] = point.x;
-    params[params.version === '1.3.0' ? 'j' : 'y'] = point.y;
-
-    let requestUrl = layer._url + L.Util.getParamString(params, layer._url, true);
-    return new Ember.RSVP.Promise((resolve, reject) => {
-      Ember.$.ajax(requestUrl, {
-        dataType: 'text'
-      }).done((data, textStatus, jqXHR) => {
-        let supportedInfoFormats = ['application/geojson', 'application/json'];
-        if (supportedInfoFormats.indexOf(layer.wmsParams.info_format) < 0) {
-          reject(new Error('Format \'' + layer.wmsParams.info_format + '\' isn\'t supported'));
-        }
-
-        let featureCollection = {};
-        try {
-          featureCollection = JSON.parse(jqXHR.responseText);
-        } catch (parseError) {
-          reject(parseError);
-        }
-
-        this.injectLeafletLayersIntoGeoJSON(featureCollection);
-
-        let features = Ember.A(Ember.get(featureCollection, 'features') || []);
-        resolve(features);
-      }).fail((jqXHR, textStatus, errorThrown) => {
-        reject(errorThrown);
-      });
+    // Set creating component's owner to avoid possible lookup exceptions.
+    let owner = Ember.getOwner(this);
+    let ownerKey = null;
+    Ember.A(Object.keys(this) || []).forEach((key) => {
+      if (this[key] === owner) {
+        ownerKey = key;
+        return false;
+      }
     });
+    if (!Ember.isBlank(ownerKey)) {
+      innerWmsLayerProperties[ownerKey] = owner;
+    }
+
+    // Create inner WMS-layer which is needed for identification (always invisible, won't be added to map).
+    this.set('_wmsLayer', WmsLayerComponent.create(innerWmsLayerProperties));
+  },
+
+  /**
+    Destroys component.
+  */
+  willDestroyElement() {
+    this._super(...arguments);
+
+    let innerWmsLayer = this.get('_wmsLayer');
+    if (!Ember.isNone(innerWmsLayer)) {
+      innerWmsLayer.destroy();
+      this.set('_wmsLayer', null);
+    }
   },
 
   /**
@@ -90,5 +108,5 @@ export default WmsLayerComponent.extend({
   */
   createLayer() {
     return L.WMS.overlayExtended(this.get('url'), this.get('options'));
-  },
+  }
 });

--- a/addon/layers/wms.js
+++ b/addon/layers/wms.js
@@ -31,6 +31,7 @@ export default TileLayer.extend({
     let settings = this._super(...arguments);
     Ember.$.extend(true, settings, {
       info_format: undefined,
+      feature_count: 100,
       url: undefined,
       version: undefined,
       layers: undefined,
@@ -58,6 +59,7 @@ export default TileLayer.extend({
     let settings = this._super(...arguments);
 
     settings.info_format = 'application/json';
+    settings.feature_count = 100;
     settings.url = record.url.split('?')[0];
     settings.version = '1.3.0';
     settings.layers = record.id;

--- a/addon/locales/en/components/layers-dialogs/settings/wms.js
+++ b/addon/locales/en/components/layers-dialogs/settings/wms.js
@@ -2,6 +2,9 @@ export default {
   'info-format-dropdown': {
     'caption': 'GetFeatureInfo-responses format'
   },
+  'feature-count-textbox': {
+    'caption': 'GetFeatureInfo-responses feature count'
+  },
   'url-textbox': {
     'caption': 'Url'
   },

--- a/addon/locales/ru/components/layers-dialogs/settings/wms.js
+++ b/addon/locales/ru/components/layers-dialogs/settings/wms.js
@@ -2,6 +2,9 @@ export default {
   'info-format-dropdown': {
     'caption': 'Формат ответов GetFeatureInfo'
   },
+  'feature-count-textbox': {
+    'caption': 'Количество объектов в ответе GetFeatureInfo'
+  },
   'url-textbox': {
     'caption': 'Url'
   },

--- a/addon/templates/components/layers-dialogs/settings/wms-single-tile.hbs
+++ b/addon/templates/components/layers-dialogs/settings/wms-single-tile.hbs
@@ -10,6 +10,15 @@
 </div>
 <div class="field">
   <label>
+    {{t "components.layers-dialogs.settings.wms.feature-count-textbox.caption"}}
+  </label>
+  {{flexberry-textbox
+    class="fluid"
+    value=settings.feature_count
+  }}
+</div>
+<div class="field">
+  <label>
     {{t "components.layers-dialogs.settings.wms-single-tile.url-textbox.caption"}}
   </label>
   {{flexberry-textbox

--- a/addon/templates/components/layers-dialogs/settings/wms.hbs
+++ b/addon/templates/components/layers-dialogs/settings/wms.hbs
@@ -10,6 +10,15 @@
 </div>
 <div class="field">
   <label>
+    {{t "components.layers-dialogs.settings.wms.feature-count-textbox.caption"}}
+  </label>
+  {{flexberry-textbox
+    class="fluid"
+    value=settings.feature_count
+  }}
+</div>
+<div class="field">
+  <label>
     {{t "components.layers-dialogs.settings.wms.url-textbox.caption"}}
   </label>
   {{flexberry-textbox

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "seiyria-bootstrap-slider": "~6.0.6",
     "jquery-minicolors": "2.2.6",
     "leaflet-minimap": "3.4.0",
-    "leaflet-wms": "1.0.0",
+    "leaflet-wms": "Flexberry/Leaflet-WMS#master",
     "leaflet.wms": "gh-pages",
     "leaflet-history": "Flexberry/leaflet-history#d67e852ae405a0ca2f6cd069d2f0ff048d7a5ce8",
     "leaflet-switch-scale-control": "0.1.0",

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "seiyria-bootstrap-slider": "~6.0.6",
     "jquery-minicolors": "2.2.6",
     "leaflet-minimap": "3.4.0",
+    "leaflet-wms": "1.0.0",
     "leaflet.wms": "gh-pages",
     "leaflet-history": "Flexberry/leaflet-history#d67e852ae405a0ca2f6cd069d2f0ff048d7a5ce8",
     "leaflet-switch-scale-control": "0.1.0",

--- a/index.js
+++ b/index.js
@@ -72,6 +72,9 @@ module.exports = {
     // Leaflet-WFST.
     app.import(app.bowerDirectory + '/Leaflet-WFST/dist/Leaflet-WFST.src.js');
 
+    // Leaflet-WMS.
+    app.import(app.bowerDirectory + '/leaflet-wms/dist/Leaflet-WMS.js');
+
     // Leaflet.WMS.
     app.import(app.bowerDirectory + '/leaflet.wms/dist/leaflet.wms.js');
 


### PR DESCRIPTION
Added usage of Leaflet-WMS plugin for identification and WMS Service's Get* requests.
Logic for layer's edit dialog's wms settings.info_format (received from GetCapabilities endpoint) and settings.feature_count (getFeatureInfo method parameter).
Remade wms-single-tile to use inner wms layer for identification.
Small refactoring of inheritance between wms and wms-single-tile

Reopened #90 with extended description

NOTE: should be tested with [Leaflet-WMS#develop](https://github.com/Flexberry/Leaflet-WMS/tree/develop)

Linked PR in Leaflet-WMS: [#3](https://github.com/Flexberry/Leaflet-WMS/pull/3)