### PR TITLE
If the editing layer is not on the map - add it

### DIFF
--- a/addon/components/flexberry-layers-attributes-panel.js
+++ b/addon/components/flexberry-layers-attributes-panel.js
@@ -524,6 +524,11 @@ export default Ember.Component.extend(LeafletZoomToFeatureMixin, {
       Ember.set(leafletMap, 'editTools', editTools);
 
       if (edit) {
+        // If the layer is not on the map - add it
+        if (!leafletMap.hasLayer(layer)) {
+          leafletMap.addLayer(layer);
+        }
+
         layer.enableEdit(leafletMap);
         leafletMap.on('editable:editing', this._triggerChanged, [tabModel, layer, true]);
       } else {


### PR DESCRIPTION
Если пользователь хочет редактировать геометрию слоя, а слоя на карте нет (случай wms-wfs слоёв) - добавляем.
Вопрос: надо ли его удалять? Если да - то когда? (Например, если не было изменений, то после выключения режима редактирования; если изменения были - то после сохранения изменений)