### PR TITLE
Add 'metadata' query param initial value in edit map controller

### DIFF
--- a/addon/controllers/edit-map.js
+++ b/addon/controllers/edit-map.js
@@ -33,7 +33,7 @@ export default EditFormController.extend(
     */
     leafletMap: null,
 
-    queryParams: ['geofilter', 'setting', 'zoom', 'lat', 'lng'],
+    queryParams: ['geofilter', 'setting', 'zoom', 'lat', 'lng', 'metadata'],
 
     /**
       Query parameter, contains json serialized object with property names and values
@@ -74,6 +74,15 @@ export default EditFormController.extend(
       @default null
     */
     lng: null,
+
+    /**
+      Query parameter, contains comma-separated ids
+      of selected layer metadata
+      @property metadata
+      @type String
+      @default null
+    */
+    metadata: null,
 
     /**
       Deserialized valued of filter property


### PR DESCRIPTION
Пару месяцев назад добавлял этот query param, и забыл начальное значение. А сейчас в прикладном проекте без этого кода при повторном заходе на урл карты значение параметра становится строковым 'null', а не null.