### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 * Change chart's library from `highcharts` to `chart.js`.
 * Change leafletLayer loading, moved from layer-styles to `layers-styles-editor` component.
+* Update dependency on the `jquery-minicolors` bower package to version `2.3.4`.
 
 ### Fixed
 * Fix legends for graduated layer-style.

--- a/blueprints/ember-flexberry-gis/index.js
+++ b/blueprints/ember-flexberry-gis/index.js
@@ -122,6 +122,12 @@ module.exports = {
       {
         name: 'chart.js',
         target: '2.7.1'
+      },
+
+      // Used in `gradients/gradient-edit` component.
+      {
+        name: 'jquery-minicolors',
+        target: '2.3.4'
       }
     ]).then(function () {
       return _this.addAddonsToProject({

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "blueimp-file-upload": "9.11.2",
     "flatpickr-calendar": "2.3.4",
     "seiyria-bootstrap-slider": "6.0.6",
-    "jquery-minicolors": "2.2.6",
+    "jquery-minicolors": "2.3.4",
     "js-beautify": "1.6.4",
     "leaflet": "1.5.1",
     "leaflet-areaselect": "d0910cc4e74b59bbd9eead447d2353c29dfe84b1",


### PR DESCRIPTION
The `jquery-minicolors` bower package from `2.2.6` to `2.3.4` versoin.