### PR TITLE
removed setting style after new row dialog approve

### DIFF
--- a/addon/components/flexberry-layers-attributes-panel.js
+++ b/addon/components/flexberry-layers-attributes-panel.js
@@ -1327,10 +1327,6 @@ export default Ember.Component.extend(LeafletZoomToFeatureMixin, {
         Ember.set(layer, 'feature', { type: 'Feature' });
         Ember.set(layer.feature, 'properties', data);
         Ember.set(layer.feature, 'leafletLayer', layer);
-        if (typeof (layer.setStyle) === 'function') {
-          layer.setStyle(Ember.get(tabModel, 'leafletObject.options.style'));
-        }
-
         tabModel.leafletObject.addLayer(layer);
       }
 


### PR DESCRIPTION
Создаю полигон, площадь залита прозрачным синим цветом
После появятся окошко "добавить" с атрибутами слоя для заполнения, закрыв окно, полигон залит непрозрачным синим
Нужно сделать так, что бы полигон оставался таким же прозрачным как и до заполнения атрибутов.