### PR TITLE
Fix 190805 edit spatial data cords

### DIFF
--- a/addon/components/geometry-add-modes/manual.js
+++ b/addon/components/geometry-add-modes/manual.js
@@ -206,7 +206,7 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
     @readonly
     @private
   */
- _availableType: null,
+  _availableType: null,
 
   menuButtonTooltip: t('components.geometry-add-modes.manual.menu-button-tooltip-add'),
 
@@ -274,7 +274,7 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
           res = factory;
           this._objectSelectType = factory.type;
         }
-      })
+      });
     }
   }),
 
@@ -290,16 +290,16 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
       this.set('_dialogVisible', true);
       switch (tabModel.typeGeometry) {
         case 'polygon' :
-          this.set('_objectTypes', this.get('_objectTypesPolygon'))
-          this._updateAvaliableTypes()
+          this.set('_objectTypes', this.get('_objectTypesPolygon'));
+          this._updateAvaliableTypes();
           break;
         case 'polyline' :
-          this.set('_objectTypes', this.get('_objectTypesLine'))
-          this._updateAvaliableTypes()
+          this.set('_objectTypes', this.get('_objectTypesLine'));
+          this._updateAvaliableTypes();
           break;
         case 'marker' :
-          this.set('_objectTypes', this.get('_objectTypesPoint'))
-          this._updateAvaliableTypes()
+          this.set('_objectTypes', this.get('_objectTypesPoint'));
+          this._updateAvaliableTypes();
           break;
       }
 
@@ -327,7 +327,7 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
                 coordinates[i][j].pop();
               }
             }
-            
+
             let multipolygonObject = this.get('_objectTypesPolygon')[1];
             this.set('_curType', i18n.t(multipolygonObject.captionPath));
             break;
@@ -592,7 +592,7 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
 
       this.set('_coordinates', null);
       this.set('_coordinatesWithError', null);
-      this.set('_curType', null)
+      this.set('_curType', null);
       this.set('_geometryField', false);
     },
 
@@ -610,7 +610,7 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
       this.set('coordinatesParseError', false);
       this.set('coordinatesInLineError', false);
       this.set('_objectSelectType', null);
-      this.set('_curType', null)
+      this.set('_curType', null);
     }
   },
 

--- a/addon/components/geometry-add-modes/manual.js
+++ b/addon/components/geometry-add-modes/manual.js
@@ -311,10 +311,9 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
       if (edit) {
         let i18n = this.get('i18n');
         const layer = Ember.get(tabModel, `featureLink.${rowId}`);
-        const geoJSON = layer.toGeoJSON();
-        const type = Ember.get(geoJSON, 'geometry.type');
-
-        let coordinates = geoJSON.geometry.coordinates;
+        const type = Ember.get(layer, 'feature.geometry.type');
+        let layerObject = Ember.$.extend(true, {}, Ember.get(layer, 'feature'));
+        let coordinates = layerObject.geometry.coordinates;
         switch (type) {
           case 'Polygon':
             coordinates.forEach(item => item.pop());

--- a/addon/components/geometry-add-modes/manual.js
+++ b/addon/components/geometry-add-modes/manual.js
@@ -171,7 +171,7 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
 
   onSelectedTpeChanged: Ember.observer('_objectSelectType', function () {
     if (!Ember.isNone(this.get('_objectSelectType'))) {
-      this.set('_geometryField', false)
+      this.set('_geometryField', false);
     }
   }),
 
@@ -498,7 +498,7 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
       this.set('_objectTypeDisabled', true);
       this.set('coordinatesParseError', false);
       this.set('coordinatesInLineError', false);
-      this.set('_objectSelectType', null)
+      this.set('_objectSelectType', null);
     }
   },
 

--- a/addon/components/geometry-add-modes/manual.js
+++ b/addon/components/geometry-add-modes/manual.js
@@ -159,16 +159,6 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
 
   coordinatesInLineErrorLabel: t('components.geometry-add-modes.manual.coordinates-line-error-label'),
 
-  pointObjectType: t('components.geometry-add-modes.manual.point-object-type'),
-
-  lineStringObjectType: t('components.geometry-add-modes.manual.linestring-object-type'),
-
-  multiLineStringObjectType: t('components.geometry-add-modes.manual.multilinestring-object-type'),
-
-  polygonObjectType: t('components.geometry-add-modes.manual.polygon-object-type'),
-
-  multipolygonObjectType: t('components.geometry-add-modes.manual.multipolygon-object-type'),
-
   onSelectedTpeChanged: Ember.observer('_objectSelectType', function () {
     if (!Ember.isNone(this.get('_objectSelectType'))) {
       this.set('_geometryField', false);
@@ -185,18 +175,18 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
     onButtonClick(tabModel) {
       this.set('_dialogHasBeenRequested', true);
       this.set('_dialogVisible', true);
-      // switch (tabModel.typeGeometry) {
-      //   case 'polygon' :
-      //     this.set('_types', [this.get('polygonObjectType'), this.get('multipolygonObjectType')]);
-      //     break;
-      //   case 'polyline' :
-      //     this.set('_types', [this.get('lineStringObjectType'),  this.get('multiLineStringObjectType')]);
-      //     break;
-      //   case 'marker' :
-      //     this.set('_types', [this.get('pointObjectType')]);
-      //     this.set('_objectSelectType', this.get('pointObjectType'));
-      //     break;
-      // }
+      switch (tabModel.typeGeometry) {
+        case 'polygon' :
+          this.set('_types', ['Polygon', 'MultiPolygon']);
+          break;
+        case 'polyline' :
+          this.set('_types', ['LineString', 'MultiLineString']);
+          break;
+        case 'marker' :
+          this.set('_types', ['Point']);
+          this.set('_objectSelectType', 'Point');
+          break;
+      }
 
       const rowId = this._getRowId(tabModel);
       const edit = Ember.get(tabModel, `_editedRows.${rowId}`);
@@ -212,7 +202,6 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
         switch (type) {
           case 'Polygon':
             coordinates.forEach(item => item.pop());
-            this.set('_objectSelectType', this.get('polygonObjectType'));
             break;
           case 'MultiPolygon':
             for (let i = 0; i < coordinates.length; i++) {
@@ -221,22 +210,12 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
               }
             }
 
-            //this.set('_objectSelectType', this.get('multipolygonObjectType'));
             break;
-          // case 'LineString':
-          //   this.set('_objectSelectType', this.get('lineStringObjectType'));
-          //   break;
-          // case ' MultiLineString':
-          //   this.set('_objectSelectType', this.get('multiLineStringObjectType'));
-          //   break;
-          // case 'Point':
-          //   this.set('_objectSelectType', this.get('pointObjectType'));
-          //   break;
         }
 
         const str = this._coordinatesToString(coordinates);
         this.set('_coordinates', str);
-
+        this.set('_objectSelectType', type);
         Ember.set(this, 'menuButtonTooltip', t('components.geometry-add-modes.manual.menu-button-tooltip-edit'));
       } else {
         this.set('_coordinates', '');

--- a/addon/components/geometry-add-modes/manual.js
+++ b/addon/components/geometry-add-modes/manual.js
@@ -133,13 +133,35 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
   /**
     Object types.
 
-    @property _geometryField
+    @property _types
     @type string[]
     @default ['Point', 'LineString', 'MultiLineString', 'Polygon', 'MultiPolygon']
     @readonly
     @private
   */
   _types: ['Point', 'LineString', 'MultiLineString', 'Polygon', 'MultiPolygon'],
+
+  /**
+    Object types in rus locale.
+
+    @property _typesRu
+    @type string[]
+    @default  ['Точка', 'Линия', 'Мультилиния', 'Полигон', 'Мультиполигон']
+    @readonly
+    @private
+  */
+  _typesRu: ['Точка', 'Линия', 'Мультилиния', 'Полигон', 'Мультиполигон'],
+
+  /**
+    Object types are avaliable to choose.
+
+    @property _typesAvaliable
+    @type string[]
+    @default  []
+    @readonly
+    @private
+  */
+  _typesAvaliable: [],
 
   menuButtonTooltip: t('components.geometry-add-modes.manual.menu-button-tooltip-add'),
 
@@ -177,14 +199,14 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
       this.set('_dialogVisible', true);
       switch (tabModel.typeGeometry) {
         case 'polygon' :
-          this.set('_types', ['Polygon', 'MultiPolygon']);
+          this.set('_typesAvaliable', ['Полигон', 'Мультиполигон']);
           break;
         case 'polyline' :
-          this.set('_types', ['LineString', 'MultiLineString']);
+          this.set('_typesAvaliable', ['Линия', 'Мультилиния']);
           break;
         case 'marker' :
-          this.set('_types', ['Point']);
-          this.set('_objectSelectType', 'Point');
+          this.set('_typesAvaliable', ['Точка']);
+          this.set('_objectSelectType', 'Точка');
           break;
       }
 
@@ -215,7 +237,9 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
 
         const str = this._coordinatesToString(coordinates);
         this.set('_coordinates', str);
-        this.set('_objectSelectType', type);
+        let index = this.get('_types').indexOf(type);
+        let typeRu = this.get('_typesRu')[index];
+        this.set('_objectSelectType', typeRu);
         Ember.set(this, 'menuButtonTooltip', t('components.geometry-add-modes.manual.menu-button-tooltip-edit'));
       } else {
         this.set('_coordinates', '');
@@ -234,8 +258,11 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
     onApprove(tabModel, e) {
       const objectSelectType = this.get('_objectSelectType');
 
+      let index = this.get('_typesRu').indexOf(objectSelectType);
+      let objectSelectTypeEn =  this.get('_types')[index];
+
       let error = false;
-      if (Ember.isNone(objectSelectType)) {
+      if (Ember.isNone(objectSelectType1)) {
         error = true;
         this.set('_geometryField', true);
       } else {
@@ -265,7 +292,6 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
 
       let baseCrs = Ember.get(tabModel, 'leafletObject.options.crs.code');
       const parsedCoordinates = this._parseStringToCoordinates(coordinates, baseCrs);
-      
 
       const rowId = this._getRowId(tabModel);
       let edit = false;
@@ -302,7 +328,7 @@ let FlexberryGeometryAddModeManualComponent = Ember.Component.extend(LeafletZoom
       let addedLayer;
       let latlngs;
 
-      switch (objectSelectType) {
+      switch (objectSelectTypeEn) {
         case 'Point':
 
           // Only one point.

--- a/addon/locales/en/components/geometry-add-modes/manual.js
+++ b/addon/locales/en/components/geometry-add-modes/manual.js
@@ -10,4 +10,9 @@ export default {
   'coordinates-parse-error-label':
    'Incorrectly entered coordinates. There must be a space between the pair of X and Y coordinates. Fractions of coordinates are indicated after the point',
   'coordinates-line-error-label': 'Incorrectly entered coordinates. The line must contain one pair of X and Y coordinates separated by a space',
+  'point-object-type' : 'Point',
+  'linestring-object-type' : 'LineString',
+  'multilinestring-object-type' : 'MultiLineString',
+  'polygon-object-type' : 'Polygon',
+  'multipolygon-object-type' : 'MultiPolygon',
 };

--- a/addon/locales/en/components/geometry-add-modes/manual.js
+++ b/addon/locales/en/components/geometry-add-modes/manual.js
@@ -10,9 +10,4 @@ export default {
   'coordinates-parse-error-label':
    'Incorrectly entered coordinates. There must be a space between the pair of X and Y coordinates. Fractions of coordinates are indicated after the point',
   'coordinates-line-error-label': 'Incorrectly entered coordinates. The line must contain one pair of X and Y coordinates separated by a space',
-  'point-object-type' : 'Point',
-  'linestring-object-type' : 'LineString',
-  'multilinestring-object-type' : 'MultiLineString',
-  'polygon-object-type' : 'Polygon',
-  'multipolygon-object-type' : 'MultiPolygon',
 };

--- a/addon/locales/en/components/geometry-add-modes/manual.js
+++ b/addon/locales/en/components/geometry-add-modes/manual.js
@@ -10,9 +10,9 @@ export default {
   'coordinates-parse-error-label':
    'Incorrectly entered coordinates. There must be a space between the pair of X and Y coordinates. Fractions of coordinates are indicated after the point',
   'coordinates-line-error-label': 'Incorrectly entered coordinates. The line must contain one pair of X and Y coordinates separated by a space',
-  'point-object-type' : 'Point',
-  'linestring-object-type' : 'LineString',
-  'multilinestring-object-type' : 'MultiLineString',
-  'polygon-object-type' : 'Polygon',
-  'multipolygon-object-type' : 'MultiPolygon',
+  'point-object-type': 'Point',
+  'linestring-object-type': 'LineString',
+  'multilinestring-object-type': 'MultiLineString',
+  'polygon-object-type': 'Polygon',
+  'multipolygon-object-type': 'MultiPolygon',
 };

--- a/addon/locales/ru/components/geometry-add-modes/manual.js
+++ b/addon/locales/ru/components/geometry-add-modes/manual.js
@@ -7,6 +7,12 @@ export default {
   'geometry-field-label': 'Тип геометрии',
   'coordinates-field-label': 'Координаты',
   'coordinates-field-placeholder': 'Добавьте координаты',
-  'coordinates-parse-error-label': 'Некорректно введены координаты. Между парой координат X и Y должен быть пробел. Доли координат указываются после точки',
+  'coordinates-parse-error-label': 'Некорректно введены координаты. Между парой координат X и Y должен быть пробел.' +
+   'Разделителем в десятичной координате должна быть точка.',
   'coordinates-line-error-label': 'Некорректно введены координаты. В строке должна содержаться одна пара координат X и Y через пробел',
+  'point-object-type' : 'Точка',
+  'linestring-object-type' : 'Линия',
+  'multilinestring-object-type' : 'Мультилиния',
+  'polygon-object-type' : 'Полигон',
+  'multipolygon-object-type' : 'Мультиполигон',
 };

--- a/addon/locales/ru/components/geometry-add-modes/manual.js
+++ b/addon/locales/ru/components/geometry-add-modes/manual.js
@@ -10,9 +10,9 @@ export default {
   'coordinates-parse-error-label': 'Некорректно введены координаты. Между парой координат X и Y должен быть пробел.' +
    'Разделителем в десятичной координате должна быть точка.',
   'coordinates-line-error-label': 'Некорректно введены координаты. В строке должна содержаться одна пара координат X и Y через пробел',
-  'point-object-type' : 'Точка',
-  'linestring-object-type' : 'Линия',
-  'multilinestring-object-type' : 'Мультилиния',
-  'polygon-object-type' : 'Полигон',
-  'multipolygon-object-type' : 'Мультиполигон',
+  'point-object-type': 'Точка',
+  'linestring-object-type': 'Линия',
+  'multilinestring-object-type': 'Мультилиния',
+  'polygon-object-type': 'Полигон',
+  'multipolygon-object-type': 'Мультиполигон',
 };

--- a/addon/locales/ru/components/geometry-add-modes/manual.js
+++ b/addon/locales/ru/components/geometry-add-modes/manual.js
@@ -10,4 +10,9 @@ export default {
   'coordinates-parse-error-label': 'Некорректно введены координаты. Между парой координат X и Y должен быть пробел.' +
    'Разделителем в десятичной координате должна быть точка.',
   'coordinates-line-error-label': 'Некорректно введены координаты. В строке должна содержаться одна пара координат X и Y через пробел',
+  'point-object-type' : 'Точка',
+  'linestring-object-type' : 'Линия',
+  'multilinestring-object-type' : 'Мультилиния',
+  'polygon-object-type' : 'Полигон',
+  'multipolygon-object-type' : 'Мультиполигон',
 };

--- a/addon/locales/ru/components/geometry-add-modes/manual.js
+++ b/addon/locales/ru/components/geometry-add-modes/manual.js
@@ -10,9 +10,4 @@ export default {
   'coordinates-parse-error-label': 'Некорректно введены координаты. Между парой координат X и Y должен быть пробел.' +
    'Разделителем в десятичной координате должна быть точка.',
   'coordinates-line-error-label': 'Некорректно введены координаты. В строке должна содержаться одна пара координат X и Y через пробел',
-  'point-object-type' : 'Точка',
-  'linestring-object-type' : 'Линия',
-  'multilinestring-object-type' : 'Мультилиния',
-  'polygon-object-type' : 'Полигон',
-  'multipolygon-object-type' : 'Мультиполигон',
 };

--- a/addon/styles/themes/blue-sky/globals/site.overrides
+++ b/addon/styles/themes/blue-sky/globals/site.overrides
@@ -83,3 +83,9 @@
     cursor:pointer;
     padding-top: 20px;
 }
+form.flexberry-geometry-add-mode-manual-form {
+     .flexberry-textarea textarea {
+        margin-left: 0px;
+        margin-right: 0px;
+    }
+}

--- a/addon/templates/components/geometry-add-modes/manual.hbs
+++ b/addon/templates/components/geometry-add-modes/manual.hbs
@@ -41,13 +41,22 @@
         </div>
       </div>
     </div>
-    <div class="field {{if _coordinatesWithError "error" ""}}">
-      <label>{{coordinatesFieldLabel}}</label>
-      {{flexberry-textarea
-        value=_coordinates
-        placeholder=coordinatesFieldPlaceholder
-      }}
+    <div class="row">
+      <div class="sixteen wide column">
+        <div class="ui grid">
+          <div class="sixteen wide column">
+          <div class="manual-textarea field {{if _coordinatesWithError "error" ""}}">
+            <label>{{coordinatesFieldLabel}}</label>
+            {{flexberry-textarea
+              value=_coordinates
+              placeholder=coordinatesFieldPlaceholder
+            }}
+          </div>
+          </div>
+        </div>
+      </div>
     </div>
+    
      {{#if (or coordinatesInLineError coordinatesParseError)}}
       <div class="ember-view ui message red">
         <ul class="list">   

--- a/addon/templates/components/geometry-add-modes/manual.hbs
+++ b/addon/templates/components/geometry-add-modes/manual.hbs
@@ -33,8 +33,8 @@
             <div class="field {{if _objectTypeDisabled "disabled" ""}} {{if _geometryField "error" ""}}">   
               <label>{{geometryFieldLabel}}</label>
               {{flexberry-dropdown
-                items=_typesAvaliable
-                value=_objectSelectType
+                items=_availableType
+                value=_curType
               }}
             </div>
           </div>

--- a/addon/templates/components/geometry-add-modes/manual.hbs
+++ b/addon/templates/components/geometry-add-modes/manual.hbs
@@ -33,7 +33,7 @@
             <div class="field {{if _objectTypeDisabled "disabled" ""}} {{if _geometryField "error" ""}}">   
               <label>{{geometryFieldLabel}}</label>
               {{flexberry-dropdown
-                items=_types
+                items=_typesAvaliable
                 value=_objectSelectType
               }}
             </div>


### PR DESCRIPTION
Исправлено:
1. Сдвинуть "Координаты" с окном для ввода координат вниз.

2. Переименовать на русский значения в выпадающем списке поля "Тип геометрии": "Линия", "Мультилиния", "Полигон", "Мультиполигон", "Точка".
 
3. Если хочу добавить объект по координатам в слое с типом геометрии "Точка", в поле "Тип геометрии" доступны и все остальные значения. Сделать, чтобы значения в поле "Тип геометрии" совпадали с типом геометрии конкретного слоя.
 
4. Ввожу координаты, поле "Тип геометрии" оставляю незаполненым, жму "Ок" - поле "Тип геометрии" выделяется красным. Выбираю значеие из выпадающего списка - поле все равно остается красным.
 
5. При закрытии окна (по кнопке "Отмена" или крестику) очищается только окно для ввода координат. Значения системы координат, типа объекта, выделения красным при некорректном вводе, ошибки - все это остается. При закрытии и повторном открытии значения должны очищаться.
 
6. Когда редактирую координаты у уже созданного объекта: удаляю координату y в одной из строк и нажимаю "Ок". В результате эта строка просто удаляется. Строка удаляться не должна, при нажатии на кнопку "Ок" должно выводиться предупреждение "Некорректно введены координаты. В строке должна содержаться одна пара координат X и Y через пробел.".
 
8. Открываю окно редактирования координат у любого объекта и, ничего не меняя, закрываю его. При повторном открытии - появляется предупреждение "Некорректно введены координаты. В строке должна содержаться одна пара координат X и Y через пробел.", хотя там ошибок быть не должно.
 
9. Открываю окно редактирования координат, внизу есть предупреждение "Некорректно введены координаты. В строке должна содержаться одна пара координат X и Y через пробел." (только оно). Меняю координаты и нажимаю на "Ок" - координаты объекта изменились. Кнопка "Ок" не должна работать, пока есть предупреждения.
 
10. При появлении предупреждения "Некорректно введены координаты. В строке должна содержаться одна пара координат X и Y через пробел." Окно ввода координат должно выделяться красным.
 
11. Заменить предупреждение "Некорректно введены координаты. Между парой координат X и Y должен быть пробел. Доли координат указываются после точки." на "Некорректно введены координаты. Между парой координат X и Y должен быть пробел. Разделителем в десятичной координате должна быть точка."
 
12. Если ввожу координаты мультиполигона (2 части), и у водной из частей указываю запятые вместо точек - полигон выводится из 1 части. В таком случае кнопка "Ок" не должна быть активна, должно появиться предупреждение "Некорректно введены координаты. Между парой координат X и Y должен быть пробел. Разделителем в десятичной координате должна быть точка." и окно ввода координат должно быть выделено красным
 
13. Если ввожу все координаты в одну строку с пробелом (координаты координаты введены через точку), появляются два предупреждения. Должно быть только "Некорректно введены координаты. В строке должна содержаться одна пара координат X и Y через пробел."