### PR TITLE
Fix tile layers overlay

### DIFF
--- a/addon/mixins/flexberry-map-actions-handler.js
+++ b/addon/mixins/flexberry-map-actions-handler.js
@@ -63,7 +63,7 @@ export default Ember.Mixin.create({
         let hierarchy = this.get('model.hierarchy').sortBy('index');
         hierarchy.forEach((layer) => {
           let leafletObject = layer.get('_leafletObject');
-          if ((leafletObject != null) && (leafletObject.bringToFront instanceof Function) && layer.get('visibility') ) {
+          if ((leafletObject != null) && (leafletObject.bringToFront instanceof Function) && layer.get('visibility')) {
             try {
               let className = Ember.get(layer, 'type');
               let layerType = Ember.getOwner(this).knownForType('layer', className);

--- a/addon/mixins/flexberry-map-actions-handler.js
+++ b/addon/mixins/flexberry-map-actions-handler.js
@@ -3,6 +3,7 @@
 */
 
 import Ember from 'ember';
+import TileLayer from '../layers/tile';
 
 /**
   Mixin containing handlers for
@@ -62,9 +63,13 @@ export default Ember.Mixin.create({
         let hierarchy = this.get('model.hierarchy').sortBy('index');
         hierarchy.forEach((layer) => {
           let leafletObject = layer.get('_leafletObject');
-          if ((leafletObject != null) && (leafletObject.bringToFront instanceof Function) && layer.get('visibility')) {
+          if ((leafletObject != null) && (leafletObject.bringToFront instanceof Function) && layer.get('visibility') ) {
             try {
-              leafletObject.bringToFront();
+              let className = Ember.get(layer, 'type');
+              let layerType = Ember.getOwner(this).knownForType('layer', className);
+              if (!(layerType instanceof TileLayer)) {
+                leafletObject.bringToFront();
+              }
             } catch (e) {
               //Terrible trouble, we need to figure it out
             }


### PR DESCRIPTION
При инициализации карты bringToFront применялся к тайловым слоям, за счет чего они перекрывали остальные wms, wfs-wms слои.
-Добавлена проверка на тип слоя перед вызовом bringToFront