### PR TITLE
Add tratment array of geometries in non/intersect

### DIFF
--- a/addon/components/compare-object-geometries-panel.js
+++ b/addon/components/compare-object-geometries-panel.js
@@ -184,7 +184,8 @@ export default Ember.Component.extend(LeafletZoomToFeatureMixin, {
     /**
       Handles click on pan to icon.
 
-      @method actions.hidePanel
+      @method actions.panToIntersection
+      @param {Object} geometry Contain intersection | non-intersection geometry. (Maybe contain many geometries)
     */
     panToIntersection(geometry) {
       let featureLayer = null;
@@ -207,7 +208,8 @@ export default Ember.Component.extend(LeafletZoomToFeatureMixin, {
     /**
       Handles click on zoom to icon.
 
-      @method actions.hidePanel
+      @method actions.zoomToIntersection
+      @param {Object} geometry Contain intersection | non-intersection geometry. (Maybe contain many geometries)
     */
     zoomToIntersection(geometry) {
       let group = this.get('featuresLayer');

--- a/addon/components/compare-object-geometries-panel.js
+++ b/addon/components/compare-object-geometries-panel.js
@@ -236,6 +236,14 @@ export default Ember.Component.extend(LeafletZoomToFeatureMixin, {
     }
   },
 
+  /**
+      Convert feature coordinate.
+
+      @method actions.zoomToIntersection
+      @param {Object} geometry Contain coordinates
+      @param {Object} style Contain style if need to paint feature
+      @returns {Object} geoJSON layer
+    */
   _convertGeometryToFeatureLayer(geometry, style) {
     if (!Ember.isBlank(geometry.coordinates[0])) {
       let copyGeometry = Object.assign({}, geometry);

--- a/addon/components/compare-object-geometries-panel.js
+++ b/addon/components/compare-object-geometries-panel.js
@@ -191,13 +191,10 @@ export default Ember.Component.extend(LeafletZoomToFeatureMixin, {
       if (geometry.type === 'GeometryCollection') {
         featureLayer = L.featureGroup();
         geometry.geometries.forEach(geom => {
-          featureLayer.addLayer(this._addConvertedGeometryToFeatureLayer(geom));
+          featureLayer.addLayer(this._convertGeometryToFeatureLayer(geom));
         });
-        let center = featureLayer.getBounds().getCenter();
-        let leafletMap = this.get('leafletMap');
-        leafletMap.panTo(center);
       } else {
-        featureLayer = this._addConvertedGeometryToFeatureLayer(geometry);
+        featureLayer = this._convertGeometryToFeatureLayer(geometry);
       }
 
       if (!Ember.isNone(featureLayer)) {
@@ -219,15 +216,12 @@ export default Ember.Component.extend(LeafletZoomToFeatureMixin, {
       if (geometry.type === 'GeometryCollection') {
         featureLayer = L.featureGroup();
         geometry.geometries.forEach(geom => {
-          featureLayer.addLayer(this._addConvertedGeometryToFeatureLayer(geom, {
+          featureLayer.addLayer(this._convertGeometryToFeatureLayer(geom, {
             style: { color: 'green' }
           }));
         });
-        let center = featureLayer.getBounds().getCenter();
-        let leafletMap = this.get('leafletMap');
-        leafletMap.panTo(center);
       } else {
-        featureLayer = this._addConvertedGeometryToFeatureLayer(geometry, {
+        featureLayer = this._convertGeometryToFeatureLayer(geometry, {
           style: { color: 'green' }
         });
       }
@@ -240,7 +234,7 @@ export default Ember.Component.extend(LeafletZoomToFeatureMixin, {
     }
   },
 
-  _addConvertedGeometryToFeatureLayer(geometry, style) {
+  _convertGeometryToFeatureLayer(geometry, style) {
     if (!Ember.isBlank(geometry.coordinates[0])) {
       let copyGeometry = Object.assign({}, geometry);
       let mapModel = this.get('mapApi').getFromApi('mapModel');

--- a/tests/unit/components/compare-object-geometries-panel-test.js
+++ b/tests/unit/components/compare-object-geometries-panel-test.js
@@ -5,11 +5,6 @@ moduleForComponent('compare-object-geometries-panel', 'Unit | Component | compar
   unit: true
 });
 
-let map = L.map(document.createElement('div'), {
-  center: [51.505, -0.09],
-  zoom: 13
-});
-
 test('test method getObjectWithProperties for GeometryCollection', function (assert) {
   assert.expect(1);
 
@@ -66,7 +61,6 @@ test('test action panToIntersection with geometry', function (assert) {
     crs: { code: 'EPSG:4356' }
   });
 
-
   let stubConvertCoordinates = sinon.stub(mapModel, '_convertObjectCoordinates');
   stubConvertCoordinates.returns({
     geometry: {
@@ -79,7 +73,7 @@ test('test action panToIntersection with geometry', function (assert) {
 
   assert.deepEqual(result.getLayers()[0].feature.geometry.type, 'Polygon');
   assert.deepEqual(result.getLayers()[0].feature.geometry.coordinates, [[[1, 2], [2, 3], [3, 4], [1, 2]]]);
-  assert.deepEqual(stubConvertCoordinates.getCall(0).args[0], 'EPSG:4356')
-  assert.deepEqual(stubConvertCoordinates.getCall(0).args[1].geometry.type, 'Polygon')
+  assert.deepEqual(stubConvertCoordinates.getCall(0).args[0], 'EPSG:4356');
+  assert.deepEqual(stubConvertCoordinates.getCall(0).args[1].geometry.type, 'Polygon');
   stubConvertCoordinates.restore();
 });

--- a/tests/unit/components/compare-object-geometries-panel-test.js
+++ b/tests/unit/components/compare-object-geometries-panel-test.js
@@ -1,7 +1,13 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import sinon from 'sinon';
 
 moduleForComponent('compare-object-geometries-panel', 'Unit | Component | compare object geometries panel', {
   unit: true
+});
+
+let map = L.map(document.createElement('div'), {
+  center: [51.505, -0.09],
+  zoom: 13
 });
 
 test('test method getObjectWithProperties for GeometryCollection', function (assert) {
@@ -40,4 +46,40 @@ test('test method getObjectWithProperties for Polygon', function (assert) {
   let component = this.subject();
   let strCoord = component.getObjectWithProperties(featurePolygon);
   assert.equal(strCoord.intersectionCoordsText, '10 30 \n40 40 \n40 20 \n20 10 \n10 30 \n');
+});
+
+test('test action panToIntersection with geometry', function (assert) {
+  assert.expect(4);
+
+  let geometry = {
+    type: 'Polygon',
+    coordinates: [[[10, 20], [20, 30], [30, 40], [10, 20]]]
+  };
+  let mapModel = {
+    _convertObjectCoordinates() {}
+  };
+
+  let component = this.subject({
+    mapApi: {
+      getFromApi() { return mapModel;}
+    },
+    crs: { code: 'EPSG:4356' }
+  });
+
+
+  let stubConvertCoordinates = sinon.stub(mapModel, '_convertObjectCoordinates');
+  stubConvertCoordinates.returns({
+    geometry: {
+      type: 'Polygon',
+      coordinates: [[[1, 2], [2, 3], [3, 4], [1, 2]]]
+    }
+  });
+
+  let result = component._convertGeometryToFeatureLayer(geometry);
+
+  assert.deepEqual(result.getLayers()[0].feature.geometry.type, 'Polygon');
+  assert.deepEqual(result.getLayers()[0].feature.geometry.coordinates, [[[1, 2], [2, 3], [3, 4], [1, 2]]]);
+  assert.deepEqual(stubConvertCoordinates.getCall(0).args[0], 'EPSG:4356')
+  assert.deepEqual(stubConvertCoordinates.getCall(0).args[1].geometry.type, 'Polygon')
+  stubConvertCoordinates.restore();
 });


### PR DESCRIPTION
Once JSTS get result of intersection or non-intersection array geometries.
Needed to process this array for the function to work correctly.