### PR TITLE
any->some

### DIFF
--- a/addon/mixins/flexberry-map-model-api-visualedit.js
+++ b/addon/mixins/flexberry-map-model-api-visualedit.js
@@ -381,7 +381,7 @@ export default Ember.Mixin.create(SnapDraw, {
             if (!Ember.isNone(featureIds) && featureIds.length > 0) {
               featureLayer = Object.values(layers).filter(feature => {
                 const layerFeatureId = this._getLayerFeatureId(e.results[0].layerModel, feature);
-                return featureIds.any((f) => { return layerFeatureId === f; });
+                return featureIds.some((f) => { return layerFeatureId === f; });
               });
             }
           } else {


### PR DESCRIPTION
Function "any" works as it should only within the framework of ember js. Since the function "any" is not in the js standard, it was decided to replace it with function "some".