### PR TITLE
Fixed layer deselection on selectAll event

### DIFF
--- a/addon/components/feature-result-item.js
+++ b/addon/components/feature-result-item.js
@@ -157,7 +157,7 @@ export default Ember.Component.extend({
     @type Boolean
     @default false
   */
-    activeScroll: false,
+  activeScroll: false,
 
   /**
     Observes and handles changes in feature.highlight state
@@ -363,6 +363,7 @@ export default Ember.Component.extend({
         behavior: 'smooth'
       });
     }
+
     this.set('activeScroll', false);
   },
   actions: {
@@ -378,18 +379,19 @@ export default Ember.Component.extend({
         this.sendAction('clearHighlights', this.get('feature'));
         Ember.set(clickedFeature, 'highlight', true);
         return;
-      };
+      }
 
       // The layer-result-list component has a zoomToAll option
       // that causes the feature.highlight state to change, which is not correct.
-      let selectedAllFeaturesInResult = !this.get('resultObject.features').find(e => e.highlight === false) && this.get('resultObject.features.length') > 1 ? true : false;
+      let selectedAllFeaturesInResult = !this.get('resultObject.features').find(e => e.highlight === false) &&
+                                        this.get('resultObject.features.length') > 1 ? true : false;
 
       // We can turn off the highlight if there was only one previous highlighted element
       Ember.set(clickedFeature, 'highlight', selectedAllFeaturesInResult ? true : !clickedFeature.highlight);
       this.sendAction('clearHighlights', clickedFeature); // clear other highlight states of feature-result-items in _displayResults.
       Ember.set(this.get('resultObject'), 'expanded', true);
       if (clickedFeature.highlight) {
-        this.set('activeScroll', true)
+        this.set('activeScroll', true);
         if (!this.get('infoExpanded')) { // open feature-result-item properties
           this.set('infoExpanded', true);
           this.set('_linksExpanded', true);
@@ -501,7 +503,7 @@ export default Ember.Component.extend({
       @method actions.panTo
      */
     panTo() {
-      this.send('highlightFeature', this.get('feature'), false)
+      this.send('highlightFeature', this.get('feature'), false);
       this.sendAction('panTo', this.get('feature'));
     },
 
@@ -510,7 +512,7 @@ export default Ember.Component.extend({
       @method actions.zoomTo
      */
     zoomTo() {
-      this.send('highlightFeature', this.get('feature'), false)
+      this.send('highlightFeature', this.get('feature'), false);
       let { bounds, leafletMap, minZoom, maxZoom } = this.getLayerPropsForZoom();
       zoomToBounds(bounds, leafletMap, minZoom, maxZoom);
     },

--- a/addon/components/feature-result-item.js
+++ b/addon/components/feature-result-item.js
@@ -301,8 +301,9 @@ export default Ember.Component.extend({
 
     this.set('defaultFeatureStyle', Object.assign({}, feature.leafletLayer.options));
 
-    if (feature.geometry.type === 'Point' || feature.geometry.type === 'MultiPoint' ||
-        feature.geometry.type === 'LineString' || feature.geometry.type === 'MultiLineString') {
+    if (feature.geometry && feature.geometry.type &&
+        (feature.geometry.type === 'Point' || feature.geometry.type === 'MultiPoint' ||
+        feature.geometry.type === 'LineString' || feature.geometry.type === 'MultiLineString')) {
       let layerTolerance = feature.layerModel.get('_leafletObject.options.renderer.options');
       if (Ember.isPresent(layerTolerance) && layerTolerance === 0) {
         Ember.set(feature.layerModel.get('_leafletObject.options.renderer.options'), 'tolerance', 3);

--- a/addon/components/layer-result-list.js
+++ b/addon/components/layer-result-list.js
@@ -189,23 +189,39 @@ export default Ember.Component.extend(LeafletZoomToFeatureMixin, {
   exportResult: null,
   actions: {
     /**
-      Сlears the highlight state of the features list.
-      @method actions.clearHighlights
+      Zooms to all features in the layer.
+      @method actions.zoomToAll
+      @param {Object} result search/identification result object.
     */
-    clearHighlights(result, clickedFeature) {
-      if (!result || !clickedFeature) {
+    zoomToAll(result) {
+      if (!result || !result.features) {
         return;
       }
 
-      let previousHighlightedFeature = this.get('selectedFeatures').find(feature => feature !== clickedFeature && Ember.get(feature, 'highlight'));
-      if (previousHighlightedFeature) {
-        Ember.set(previousHighlightedFeature, 'highlight', false);
+      if (!this.get('enableHighlight')) {
+        this.send('zoomTo', result.features);
+        return;
       }
 
-      Ember.set(clickedFeature, 'highlight', !clickedFeature.highlight);
+      result.features.forEach(feature => Ember.set(feature, 'highlight', true));
+      this.send('clearHighlights', result.features);
+      this.send('zoomTo', result.features, this.get('enableHighlight'), false);
+    },
 
-      if(clickedFeature === true) {
-        Ember.set(result, 'expanded', true)
+    /**
+      Сlears the highlight state of selectedFeatures elements (all found features).
+      @method actions.clearHighlights
+      @param {Array} clickedFeatures list of objects for which the "highlight" state changes
+    */
+    clearHighlights(clickedFeatures) {
+      if (Ember.isArray(clickedFeatures)) {
+        this.get('selectedFeatures')
+          .filter(feature => clickedFeatures.indexOf(feature) === -1 && Ember.get(feature, 'highlight'))
+          .forEach(feature => Ember.set(feature, 'highlight', false));
+      } else {
+        this.get('selectedFeatures')
+          .filter(feature => feature !== clickedFeatures && Ember.get(feature, 'highlight'))
+          .forEach(feature => Ember.set(feature, 'highlight', false));
       }
     },
     /**

--- a/addon/components/layer-result-list.js
+++ b/addon/components/layer-result-list.js
@@ -203,7 +203,10 @@ export default Ember.Component.extend(LeafletZoomToFeatureMixin, {
       }
 
       Ember.set(clickedFeature, 'highlight', !clickedFeature.highlight);
-      Ember.set(result, 'highlight', true);
+
+      if(clickedFeature === true) {
+        Ember.set(result, 'expanded', true)
+      }
     },
     /**
       Show\hide links list (if present).
@@ -432,6 +435,7 @@ export default Ember.Component.extend(LeafletZoomToFeatureMixin, {
               features: this.get('maxResultsCount') ? Ember.A(features).slice(0, this.get('maxResultsCount')) : Ember.A(features),
               maxResultsLimitOverage: this.get('maxResultsCount') && features.length > this.get('maxResultsCount') ? true : false,
               highlight: false,
+              expanded: features.length === 1,
               layerModel: layerModel,
               hasListForm: hasListForm,
               layerIds: layerIds,

--- a/addon/mixins/leaflet-zoom-to-feature.js
+++ b/addon/mixins/leaflet-zoom-to-feature.js
@@ -21,8 +21,9 @@ export default Ember.Mixin.create({
       @method actions.selectFeature
       @param {Object} feature Describes inner FeatureResultItem's feature object or array of it.
       @param {Boolean} layerInteractive Flag indicating whether to enable layer interactivity.
+      @param {Boolean} clearLayers Flag indicating whether to clear the result service layer.
     */
-    selectFeature(feature, layerInteractive) {
+    selectFeature(feature, layerInteractive = false, clearLayers = true) {
       let leafletMap = this.get('leafletMap');
       if (Ember.isNone(leafletMap)) {
         return;
@@ -36,7 +37,7 @@ export default Ember.Mixin.create({
 
       let selectedFeature = this.get('_selectedFeature');
       if (selectedFeature !== feature) {
-        serviceLayer.clearLayers();
+        clearLayers ? serviceLayer.clearLayers() : null;
 
         if (Ember.isArray(feature)) {
           feature.forEach((item) => this._selectFeature(item, layerInteractive));
@@ -56,14 +57,15 @@ export default Ember.Mixin.create({
       @method actions.zoomTo
       @param {Object} feature Describes inner FeatureResultItem's feature object or array of it.
       @param {Boolean} layerInteractive Flag indicating whether to enable layer interactivity.
+      @param {Boolean} clearLayers Flag indicating whether to clear the result service layer.
     */
-    zoomTo(feature, layerInteractive) {
+    zoomTo(feature, layerInteractive = false, clearLayers = true) {
       let leafletMap = this.get('leafletMap');
       if (Ember.isNone(leafletMap)) {
         return;
       }
 
-      this.send('selectFeature', feature, layerInteractive);
+      this.send('selectFeature', feature, layerInteractive, clearLayers);
 
       let bounds;
       let serviceLayer = this.get('serviceLayer');

--- a/addon/mixins/leaflet-zoom-to-feature.js
+++ b/addon/mixins/leaflet-zoom-to-feature.js
@@ -37,7 +37,9 @@ export default Ember.Mixin.create({
 
       let selectedFeature = this.get('_selectedFeature');
       if (selectedFeature !== feature) {
-        clearLayers ? serviceLayer.clearLayers() : null;
+        if (clearLayers) {
+          serviceLayer.clearLayers();
+        }
 
         if (Ember.isArray(feature)) {
           feature.forEach((item) => this._selectFeature(item, layerInteractive));

--- a/addon/mixins/leaflet-zoom-to-feature.js
+++ b/addon/mixins/leaflet-zoom-to-feature.js
@@ -13,6 +13,8 @@ import { zoomToBounds } from '../utils/zoom-to-bounds';
 */
 export default Ember.Mixin.create({
 
+  serviceRenderer: null,
+
   actions: {
     /**
       Handles inner FeatureResultItem's bubbled 'selectFeature' action.
@@ -29,6 +31,11 @@ export default Ember.Mixin.create({
         return;
       }
 
+      let serviceRenderer = this.get('serviceRenderer');
+      if (Ember.isNone(serviceRenderer)) {
+        serviceRenderer = L.canvas({ pane: 'overlayPane' });
+      }
+
       let serviceLayer = this.get('serviceLayer');
       if (Ember.isNone(serviceLayer)) {
         serviceLayer = L.featureGroup().addTo(leafletMap);
@@ -42,7 +49,10 @@ export default Ember.Mixin.create({
         }
 
         if (Ember.isArray(feature)) {
-          feature.forEach((item) => this._selectFeature(item, layerInteractive));
+
+          // Adding objects to the layer (serviceRenderer) occurs at the end, which confuses the hierarchy on the map.
+          // Correct addition, taking into account indexes - to the beginning
+          feature.reverse().forEach((item) => this._selectFeature(item, layerInteractive));
         } else {
           this._selectFeature(feature, layerInteractive);
         }
@@ -143,6 +153,13 @@ export default Ember.Mixin.create({
   */
   _prepareLayer(layer, layerInteractive) {
     layer.options.interactive = layerInteractive ? true : false;
+    if (layerInteractive) {
+      layer.options.pane = 'overlayPane';
+
+      let serviceRenderer = this.get('serviceRenderer');
+      layer.options.renderer = serviceRenderer;
+    }
+
     return layer;
   },
 

--- a/addon/templates/components/layer-result-list.hbs
+++ b/addon/templates/components/layer-result-list.hbs
@@ -12,7 +12,7 @@
         {{#if (eq intersection false)}}
           <a class="feature-result-item-select icon item"
             title="{{t "components.feature-result-item.select-all-caption"}}"
-            {{action "zoomTo" result.features}}>
+            {{action "zoomTo" result.features enableHighlight false}}>
               <i class="icon-guideline-marker"></i>
           </a>
         {{/if}}
@@ -137,7 +137,7 @@
       <div class="feature-result-item-buttons hidden">
         <a class="feature-result-item-select icon item"
           title="{{t "components.feature-result-item.select-all-caption"}}"
-          {{action "zoomTo" result.features}}>
+          {{action "zoomTo" result.features enableHighlight false}}>
           {{#if (eq intersection false)}}
           <i class="icon-guideline-marker"></i>
           {{/if}}

--- a/addon/templates/components/layer-result-list.hbs
+++ b/addon/templates/components/layer-result-list.hbs
@@ -12,7 +12,7 @@
         {{#if (eq intersection false)}}
           <a class="feature-result-item-select icon item"
             title="{{t "components.feature-result-item.select-all-caption"}}"
-            {{action "zoomTo" result.features enableHighlight false}}>
+            {{action "zoomToAll" result}}>
               <i class="icon-guideline-marker"></i>
           </a>
         {{/if}}
@@ -89,8 +89,9 @@
                 {{#if (known-for-type 'component' (concat 'feature-result-item-' result.layerModel.type))}}
                   {{component (concat 'feature-result-item-' result.layerModel.type)
                     feature=feature
-                    highlightable= enableHighlight
-                    clearHighlights= (action "clearHighlights" result)
+                    resultObject=result
+                    highlightable=enableHighlight
+                    clearHighlights=(action "clearHighlights")
                     infoExpanded=(and (eq result.features.length 1) result.first)
                     displayProperty="displayValue"
                     displaySettings=result.settings
@@ -109,8 +110,9 @@
                 {{else}}
                   {{feature-result-item
                     feature=feature
-                    highlightable= enableHighlight
-                    clearHighlights= (action "clearHighlights" result)
+                    resultObject=result
+                    highlightable=enableHighlight
+                    clearHighlights=(action "clearHighlights")
                     infoExpanded=(and (eq result.features.length 1) result.first)
                     displayProperty="displayValue"
                     displaySettings=result.settings
@@ -137,7 +139,7 @@
       <div class="feature-result-item-buttons hidden">
         <a class="feature-result-item-select icon item"
           title="{{t "components.feature-result-item.select-all-caption"}}"
-          {{action "zoomTo" result.features enableHighlight false}}>
+          {{action "zoomToAll" result}}>
           {{#if (eq intersection false)}}
           <i class="icon-guideline-marker"></i>
           {{/if}}
@@ -213,9 +215,10 @@
             {{#if (known-for-type 'component' (concat 'feature-result-item-' result.layerModel.type))}}
             {{component (concat 'feature-result-item-' result.layerModel.type)
                 feature=feature
+                resultObject=result
                 displayProperty="displayValue"
-                highlightable= enableHighlight
-                clearHighlights= (action "clearHighlights" result)
+                highlightable=enableHighlight
+                clearHighlights=(action "clearHighlights")
                 displaySettings=result.settings
                 selectedFeature=_selectedFeature
                 selectFeature=(action "selectFeature")
@@ -235,10 +238,11 @@
             {{else}}
               {{feature-result-item
                 feature=feature
+                resultObject=result
                 displayProperty="displayValue"
                 displaySettings=result.settings
-                highlightable= enableHighlight
-                clearHighlights= (action "clearHighlights" result)
+                highlightable=enableHighlight
+                clearHighlights=(action "clearHighlights")
                 selectedFeature=_selectedFeature
                 selectFeature=(action "selectFeature")
                 panTo=(action "panTo")

--- a/addon/templates/components/layer-result-list.hbs
+++ b/addon/templates/components/layer-result-list.hbs
@@ -81,8 +81,8 @@
           </a>
         {{/if}}
       </div>
-      {{#flexberry-toggler caption=result.name expanded=(or (and (eq result.features.length 1) result.first) result.highlight) class='layer-result-list-toggler'}}
-        <div class="ui list transition">
+      {{#flexberry-toggler caption=result.name expanded=result.expanded class='layer-result-list-toggler'}}
+        <div class="ui list transition {{if result.expanded "visible" "hidden"}}">
           {{#if intersection}}
             {{#each result.features as |feature|}}
               {{#if feature.isIntersect}}
@@ -207,8 +207,8 @@
           </a>
         {{/if}}
       </div>
-      {{#flexberry-toggler caption=result.name expanded=(or (and (eq result.features.length 1) result.first) result.highlight) class='layer-result-list-toggler'}}
-        <div class="ui list transition">
+      {{#flexberry-toggler caption=result.name expanded=result.expanded class='layer-result-list-toggler'}}
+        <div class="ui list transition {{if result.expanded "visible" "hidden"}}">
           {{#each result.features as |feature|}}
             {{#if (known-for-type 'component' (concat 'feature-result-item-' result.layerModel.type))}}
             {{component (concat 'feature-result-item-' result.layerModel.type)

--- a/tests/dummy/app/templates/map.hbs
+++ b/tests/dummy/app/templates/map.hbs
@@ -143,6 +143,7 @@
           results=searchResults
           serviceLayer=serviceLayer
           leafletMap=leafletMap
+          serviceRenderer=serviceRenderer
           showIntersectionPanel=(action 'onIntersectionPanel')
           featureSelected=(action "onLayerFeatureSelected")
           addToFavorite=(action "addToFavorite")
@@ -168,6 +169,7 @@
           results=identifyToolResults
           serviceLayer=serviceLayer
           leafletMap=leafletMap
+          serviceRenderer=serviceRenderer
           showIntersectionPanel=(action 'onIntersectionPanel')
           featureSelected=(action "onLayerFeatureSelected")
           addToFavorite=(action "addToFavorite")


### PR DESCRIPTION
[[228064](https://dis-dev-ops.ics.perm.ru/Common/RGISPermKrai/_workitems/edit/228064/)]
### Done:
- Layer deselection on selectAll event
- Error in selecting a feature that is lower in the layer hierarchy
- Added zoomToAll method
- Fixed bug with random expand in search results panel
- Refactored
