### PR TITLE
fixed duplication in the display of wms legend rules

### DIFF
--- a/addon/components/legends/wms-legend.js
+++ b/addon/components/legends/wms-legend.js
@@ -90,7 +90,6 @@ export default BaseLegendComponent.extend({
                   if (response && response.Legend && response.Legend[0]) {
                     // One legend per query.
                     let legendsContainer = [];
-                    debugger;
                     response.Legend[0].rules.forEach(rule => {
                       if (!rule || !rule.symbolizers) {
                         return;

--- a/addon/components/legends/wms-legend.js
+++ b/addon/components/legends/wms-legend.js
@@ -95,8 +95,8 @@ export default BaseLegendComponent.extend({
                         return;
                       }
 
-                      let textSymbolizers = rule.symbolizers.filter(symbolizer => Object.keys(symbolizer).filter(name => name !== 'Text').length > 0);
-                      if (textSymbolizers.length === 0) {
+                      let nonTextSymbolizers = rule.symbolizers.filter(symbolizer => Object.keys(symbolizer).filter(name => name !== 'Text').length > 0);
+                      if (nonTextSymbolizers.length === 0) {
                         return;
                       }
 

--- a/addon/components/legends/wms-legend.js
+++ b/addon/components/legends/wms-legend.js
@@ -90,7 +90,17 @@ export default BaseLegendComponent.extend({
                   if (response && response.Legend && response.Legend[0]) {
                     // One legend per query.
                     let legendsContainer = [];
+                    debugger;
                     response.Legend[0].rules.forEach(rule => {
+                      if (!rule || !rule.symbolizers) {
+                        return;
+                      }
+
+                      let textSymbolizers = rule.symbolizers.filter(symbolizer => Object.keys(symbolizer).filter(name => name !== 'Text').length > 0);
+                      if (textSymbolizers.length === 0) {
+                        return;
+                      }
+
                       parameters.rule = rule.name;
                       parameters.format = 'image/png';
                       parameters.width = legendImageScale;


### PR DESCRIPTION
- only text symbolizes (having the attribute 'Text') are not requested from the geoserver