### PR TITLE
fixed method "resetLayer" in terms of deleting layer labels

### DIFF
--- a/addon/components/base-layer.js
+++ b/addon/components/base-layer.js
@@ -664,9 +664,10 @@ export default Ember.Component.extend(
         });
       }
 
-      if (this.get('labelSettings.signMapObjects') && !Ember.isNone(this.get('_labelsLayer')) &&
-        leafletContainer.hasLayer(this.get('_labelsLayer'))) {
-        leafletContainer.removeLayer(this.get('_labelsLayer'));
+      let labelsLayer = this.get('_labelsLayer');
+      if (!Ember.isNone(labelsLayer) && leafletContainer.hasLayer(labelsLayer)) {
+        labelsLayer.clearLayers();
+        leafletContainer.removeLayer(labelsLayer);
       }
     },
 

--- a/addon/components/base-vector-layer.js
+++ b/addon/components/base-vector-layer.js
@@ -1069,7 +1069,7 @@ export default BaseLayer.extend({
     leafletObject.clearLayers();
 
     if (this.get('labelSettings.signMapObjects') && !Ember.isNone(this.get('_labelsLayer')) &&
-      !Ember.isNone(this.get('_leafletObject._labelsLayeri'))) {
+      !Ember.isNone(this.get('_leafletObject._labelsLayer'))) {
       leafletObject._labelsLayer.eachLayer((layerShape) => {
         if (map.hasLayer(layerShape)) {
           map.removeLayer(layerShape);


### PR DESCRIPTION
Changing the layer settings triggers the `base-layer/leafletOptionsDidChange` handler, which executes 
`_resetLayer->_destroyLayer->`[_removeLayerFromLeafletContainer](https://github.com/Flexberry/ember-flexberry-gis/blob/446fdc269270b9bd9f7a872e54187bb015cb6d4c/addon/components/base-layer.js#L649), 
removing the previous leafletLayer instance from the leafletContainer

`this.get('_labelsLayer')` of labels is a linked separate layer with `this.get('_leafletObject')`
and will be removed only when `this.get('labelSettings.signMapObjects') === true`

But `this.get('labelSettings.signMapObjects')` can be changed BEFORE _resetLayer, which will leave `this.get('_labelsLayer') `in the leafletContainer.

It is necessary to remove `this.get('_labelsLayer') `from the leafletContainer whenever _removeLayerFromLeafletContainer is called