### PR TITLE
fixed method "resetLayer" in terms of deleting layer labels [rgis-develop]

### DIFF
--- a/addon/components/base-layer.js
+++ b/addon/components/base-layer.js
@@ -417,6 +417,8 @@ export default Ember.Component.extend(
       // Now execute base destroy logic.
       this._removeLayerFromLeafletContainer();
 
+      this._removeLabelsFromLeafletContainer();
+
       if (this.get('labelSettings.signMapObjects') && !Ember.isNone(this.get('additionalZoomLabel'))) {
         this.set('additionalZoomLabel', null);
       }
@@ -554,6 +556,7 @@ export default Ember.Component.extend(
         this._addLayerToLeafletContainer();
       } else {
         this._removeLayerFromLeafletContainer();
+        this._removeLabelsFromLeafletContainer();
       }
     },
 
@@ -655,8 +658,17 @@ export default Ember.Component.extend(
       }
 
       leafletContainer.removeLayer(leafletLayer);
+    },
 
-      if (this.get('labelSettings.signMapObjects') && !Ember.isNone(this.get('additionalZoomLabel'))) {
+    /**
+      Removes labels from it's leaflet container.
+
+      @method _removeLabelsFromLeafletContainer
+      @private
+    */
+    _removeLabelsFromLeafletContainer() {
+      let leafletContainer = this.get('leafletContainer');
+      if (!Ember.isNone(this.get('additionalZoomLabel'))) {
         this.get('additionalZoomLabel').forEach(zoomLabels => {
           if (leafletContainer.hasLayer(zoomLabels)) {
             leafletContainer.removeLayer(zoomLabels);
@@ -666,7 +678,6 @@ export default Ember.Component.extend(
 
       let labelsLayer = this.get('_labelsLayer');
       if (!Ember.isNone(labelsLayer) && leafletContainer.hasLayer(labelsLayer)) {
-        labelsLayer.clearLayers();
         leafletContainer.removeLayer(labelsLayer);
       }
     },

--- a/addon/components/base-layer.js
+++ b/addon/components/base-layer.js
@@ -664,9 +664,10 @@ export default Ember.Component.extend(
         });
       }
 
-      if (this.get('labelSettings.signMapObjects') && !Ember.isNone(this.get('_labelsLayer')) &&
-        leafletContainer.hasLayer(this.get('_labelsLayer'))) {
-        leafletContainer.removeLayer(this.get('_labelsLayer'));
+      let labelsLayer = this.get('_labelsLayer');
+      if (!Ember.isNone(labelsLayer) && leafletContainer.hasLayer(labelsLayer)) {
+        labelsLayer.clearLayers();
+        leafletContainer.removeLayer(labelsLayer);
       }
     },
 

--- a/addon/components/base-vector-layer.js
+++ b/addon/components/base-vector-layer.js
@@ -2279,28 +2279,6 @@ export default BaseLayer.extend({
   },
 
   /**
-    Removes labels from it's leaflet container.
-
-    @method _removeLabelsFromLeafletContainer
-    @private
-  */
-  _removeLabelsFromLeafletContainer() {
-    let leafletMap = this.get('leafletMap');
-
-    let additionalZoomLabel = this.get('additionalZoomLabel');
-    if (additionalZoomLabel && additionalZoomLabel.length > 0) {
-      additionalZoomLabel.forEach(zoomLabels => {
-        leafletMap.removeLayer(zoomLabels);
-      });
-    }
-
-    let _labelsLayer = this.get('_labelsLayer');
-    if (!Ember.isNone(_labelsLayer)) {
-      leafletMap.removeLayer(_labelsLayer);
-    }
-  },
-
-  /**
     Sets leaflet layer's visibility.
 
     @method _setLayerVisibility
@@ -2319,11 +2297,23 @@ export default BaseLayer.extend({
       }
     } else {
       this._removeLayerFromLeafletContainer();
-      if (this.get('labelSettings.signMapObjects') && !Ember.isNone(this.get('_labelsLayer')) &&
-        !Ember.isNone(this.get('_leafletObject._labelsLayer'))) {
-        this._removeLabelsFromLeafletContainer();
-      }
+      this._removeLabelsFromLeafletContainer();
     }
+  },
+
+   /**
+    Gets feature properties as plain object.
+    this is necessary to get properties from odata-vector-layer feature
+
+    @method _setLayerVisibility
+    @private
+  */
+  _getRegularProperties() {
+    if (!this || Ember.get(this, 'feature') || Ember.get(this, 'feature.properties')) {
+      return null;
+    }
+
+    return Ember.get(this, 'feature.properties');
   },
 
   _getGeometry(layer) {

--- a/addon/components/base-vector-layer.js
+++ b/addon/components/base-vector-layer.js
@@ -1069,7 +1069,7 @@ export default BaseLayer.extend({
     leafletObject.clearLayers();
 
     if (this.get('labelSettings.signMapObjects') && !Ember.isNone(this.get('_labelsLayer')) &&
-      !Ember.isNone(this.get('_leafletObject._labelsLayeri'))) {
+      !Ember.isNone(this.get('_leafletObject._labelsLayer'))) {
       leafletObject._labelsLayer.eachLayer((layerShape) => {
         if (map.hasLayer(layerShape)) {
           map.removeLayer(layerShape);

--- a/addon/components/layers/odata-vector-layer.js
+++ b/addon/components/layers/odata-vector-layer.js
@@ -730,10 +730,21 @@ export default BaseVectorLayer.extend({
     }
 
     layers.forEach((layer) => {
+      layer._getRegularProperties = this.get('_getRegularProperties').bind(layer);
       leafletObject.addLayer(layer, leafletObject);
     });
 
     this._super(...arguments);
+  },
+
+  _getRegularProperties() {
+    return Object.keys(this.feature.properties).reduce((accamulator, currentkey) => {
+      if (currentkey === 'primarykey') {
+        return accamulator;
+      }
+      accamulator[currentkey] = this.feature.properties[currentkey]
+      return accamulator;
+    }, {});
   },
 
   /**

--- a/addon/components/layers/wfs-layer.js
+++ b/addon/components/layers/wfs-layer.js
@@ -174,6 +174,7 @@ export default BaseVectorLayer.extend({
           layer.options.shadowPane = pane;
         }
 
+        layer._getRegularProperties = this.get('_getRegularProperties').bind(layer);
         layer.options.pane = pane;
         layer.options.renderer = this.get('_renderer');
       }

--- a/addon/components/select-with-checkbox.js
+++ b/addon/components/select-with-checkbox.js
@@ -141,8 +141,9 @@ export default FlexberryDropdown.extend({
         if (this.get('isObject')) {
           value = Ember.get(val, this.get('propertyName'));
           key = val.id;
-          if (this.get('propertyHelp'))
+          if (this.get('propertyHelp')) {
             help = Ember.get(val, this.get('propertyHelp'));
+          }
         }
 
         return Ember.Object.create({ key, value, help, isVisible: false });
@@ -170,8 +171,9 @@ export default FlexberryDropdown.extend({
 
     clearAll(event) {
       //click action is defined as a DOM event to cancel the semantic dropdown action
-      if (event)
+      if (event) {
         event.stopPropagation();
+      }
       this.get('state').setEach('isVisible', false);
       this.sendAction('clearAll');
     },


### PR DESCRIPTION
Changing the layer settings triggers the base-layer/leafletOptionsDidChange handler, which executes
_resetLayer->_destroyLayer->[_removeLayerFromLeafletContainer](https://github.com/Flexberry/ember-flexberry-gis/blob/446fdc269270b9bd9f7a872e54187bb015cb6d4c/addon/components/base-layer.js#L649),
removing the previous leafletLayer instance from the leafletContainer

this.get('_labelsLayer') of labels is a linked separate layer with this.get('_leafletObject')
and will be removed only when this.get('labelSettings.signMapObjects') === true

But this.get('labelSettings.signMapObjects') can be changed BEFORE _resetLayer, which will leave this.get('_labelsLayer') in the leafletContainer.

It is necessary to remove this.get('_labelsLayer') from the leafletContainer whenever _removeLayerFromLeafletContainer is called