### PR TITLE
fix scroll in layer-result-list

### DIFF
--- a/addon/components/feature-result-item.js
+++ b/addon/components/feature-result-item.js
@@ -430,7 +430,10 @@ export default Ember.Component.extend(ResultFeatureInitializer, {
       Ember.set(this.get('resultObject'), 'expanded', true);
       if (clickedFeature.highlight) {
         this.set('activeScroll', true);
-        this.set('infoExpanded', false); // trigger didRender hook manually
+        if (this.get('infoExpanded')) {
+          this.set('infoExpanded', false); // trigger didRender hook manually
+        }
+
         this.set('infoExpanded', true); // open feature-result-item properties
         this.set('_linksExpanded', true);
       }

--- a/addon/components/feature-result-item.js
+++ b/addon/components/feature-result-item.js
@@ -430,10 +430,9 @@ export default Ember.Component.extend(ResultFeatureInitializer, {
       Ember.set(this.get('resultObject'), 'expanded', true);
       if (clickedFeature.highlight) {
         this.set('activeScroll', true);
-        if (!this.get('infoExpanded')) { // open feature-result-item properties
-          this.set('infoExpanded', true);
-          this.set('_linksExpanded', true);
-        }
+        this.set('infoExpanded', false); // trigger didRender hook manually
+        this.set('infoExpanded', true); // open feature-result-item properties
+        this.set('_linksExpanded', true);
       }
     },
     /**

--- a/addon/components/feature-result-item.js
+++ b/addon/components/feature-result-item.js
@@ -430,6 +430,9 @@ export default Ember.Component.extend(ResultFeatureInitializer, {
       Ember.set(this.get('resultObject'), 'expanded', true);
       if (clickedFeature.highlight) {
         this.set('activeScroll', true);
+
+        // Feature highlighting doesn't trigger didRender hook
+        // You need to toggle the template property to trigger it and scroll the list
         if (this.get('infoExpanded')) {
           this.set('infoExpanded', false); // trigger didRender hook manually
         }


### PR DESCRIPTION
 - **case**: changing feature background on highlight in result-list does not trigger didRender ember component hook so the feature-result-item will not be shown
![bug](https://github.com/Flexberry/ember-flexberry-gis/assets/49162494/7fbf8bb5-f804-4b8c-9937-08d08456226d)

- **solution**:  trigger didRender hook manually togglering <infoExpanded> template prop on feature highlight.
![fix](https://github.com/Flexberry/ember-flexberry-gis/assets/49162494/1944c3a9-64cb-4f65-ac86-6b751a55fd9d)
