### PR TITLE
edit-layer-feature validation state on canceling

### DIFF
--- a/addon/components/flexberry-edit-layer-feature.js
+++ b/addon/components/flexberry-edit-layer-feature.js
@@ -814,6 +814,7 @@ export default Ember.Component.extend(SnapDrawMixin, LeafletZoomToFeatureMixin, 
     this.set('latlngs', null);
     this.set('layers', null);
     this.set('isLayerCopy', false);
+    this.set('parsingErrors', {});
 
     this.set('data', null);
     this.set('initialData', null);


### PR DESCRIPTION
- fixed restoring the state of component properties when canceling an edit