### PR TITLE
#37 Текущие ошибки версии 31.07.2025

### DIFF
--- a/addon/components/base-vector-layer.js
+++ b/addon/components/base-vector-layer.js
@@ -281,348 +281,276 @@ export default BaseLayer.extend(layerLabel, {
     }.bind(this));
   },
 
-/**
-  Creates leaflet vector layer related to layer type.
+  /**
+    Creates leaflet vector layer related to layer type.
 
-  @method createVectorLayer
-  @param {Object} options Layer options.
-  @returns <a href="http://leafletjs.com/reference-1.0.1.html#layer">L.Layer</a>|<a href="https://emberjs.com/api/classes/RSVP.Promise.html">Ember.RSVP.Promise</a>
-  Leaflet layer or promise returning such layer.
-*/
-createVectorLayer(options) {
-  assert('BaseVectorLayer\'s \'createVectorLayer\' should be overridden.');
-},
+    @method createVectorLayer
+    @param {Object} options Layer options.
+    @returns <a href="http://leafletjs.com/reference-1.0.1.html#layer">L.Layer</a>|<a href="https://emberjs.com/api/classes/RSVP.Promise.html">Ember.RSVP.Promise</a>
+    Leaflet layer or promise returning such layer.
+  */
+  createVectorLayer(options) {
+    assert('BaseVectorLayer\'s \'createVectorLayer\' should be overridden.');
+  },
 
-/**
-  Creates read format for the specified leaflet vector layer.
+  /**
+    Creates read format for the specified leaflet vector layer.
 
-  @method createReadFormat
-  @param {<a href="http://leafletjs.com/reference-1.0.1.html#layer">L.Layer</a>} Leaflet layer.
-  @returns {Object} Read format.
-*/
-createReadFormat(vectorLayer) {
-  let crs = this.get('crs');
-  let geometryField = 'geometry';
-  let readFormat = new L.Format.GeoJSON({ crs, geometryField });
+    @method createReadFormat
+    @param {<a href="http://leafletjs.com/reference-1.0.1.html#layer">L.Layer</a>} Leaflet layer.
+    @returns {Object} Read format.
+  */
+  createReadFormat(vectorLayer) {
+    let crs = this.get('crs');
+    let geometryField = 'geometry';
+    let readFormat = new L.Format.GeoJSON({ crs, geometryField });
 
-  let layerPropertiesDescription = ``;
-  let layerClass = Ember.getOwner(this).lookup(`layer:${this.get('layerModel.type')}`);
-  let layerProperties = layerClass.getLayerProperties(vectorLayer);
-  for (let i = 0, len = layerProperties.length; i < len; i++) {
-    let layerProperty = layerProperties[i];
-    let layerPropertyValue = layerClass.getLayerPropertyValues(vectorLayer, layerProperty, 1)[0];
+    let layerPropertiesDescription = ``;
+    let layerClass = Ember.getOwner(this).lookup(`layer:${this.get('layerModel.type')}`);
+    let layerProperties = layerClass.getLayerProperties(vectorLayer);
+    for (let i = 0, len = layerProperties.length; i < len; i++) {
+      let layerProperty = layerProperties[i];
+      let layerPropertyValue = layerClass.getLayerPropertyValues(vectorLayer, layerProperty, 1)[0];
 
-    let layerPropertyType = typeof layerPropertyValue;
-    switch (layerPropertyType) {
-      case 'boolean':
-        layerPropertyType = 'boolean';
-        break;
-      case 'number':
-        layerPropertyType = 'decimal';
-        break;
-      case 'object':
-        layerPropertyType = layerPropertyValue instanceof Date ? 'date' : 'string';
-        break;
-      default:
-        layerPropertyType = 'string';
+      let layerPropertyType = typeof layerPropertyValue;
+      switch (layerPropertyType) {
+        case 'boolean':
+          layerPropertyType = 'boolean';
+          break;
+        case 'number':
+          layerPropertyType = 'decimal';
+          break;
+        case 'object':
+          layerPropertyType = layerPropertyValue instanceof Date ? 'date' : 'string';
+          break;
+        default:
+          layerPropertyType = 'string';
+      }
+
+      layerPropertiesDescription += `<xsd:element maxOccurs="1" minOccurs="0" name="${layerProperty}" nillable="true" type="xsd:${layerPropertyType}"/>`;
     }
 
-    layerPropertiesDescription += `<xsd:element maxOccurs="1" minOccurs="0" name="${layerProperty}" nillable="true" type="xsd:${layerPropertyType}"/>`;
-  }
+    let describeFeatureTypeResponse = `` +
+      `<?xml version="1.0" encoding="UTF-8"?>` +
+      `<xsd:schema xmlns:gml="http://www.opengis.net/gml" ` +
+      `xmlns:flexberry="http://flexberry.ru" ` +
+      `xmlns:xsd="http://www.w3.org/2001/XMLSchema" ` +
+      `elementFormDefault="qualified" ` +
+      `targetNamespace="http://flexberry.ru">` +
+      `<xsd:import namespace="http://www.opengis.net/gml" schemaLocation="http://flexberry.ru/schemas/gml/3.1.1/base/gml.xsd"/>` +
+      `<xsd:complexType name="layerType">` +
+      `<xsd:complexContent>` +
+      `<xsd:extension base="gml:AbstractFeatureType">` +
+      `<xsd:sequence>` +
+      `${layerPropertiesDescription}` +
+      `<xsd:element maxOccurs="1" minOccurs="0" name="${geometryField}" nillable="true" type="gml:GeometryPropertyType"/>` +
+      `</xsd:sequence>` +
+      `</xsd:extension>` +
+      `</xsd:complexContent>` +
+      `</xsd:complexType>` +
+      `<xsd:element name="layer" substitutionGroup="gml:_Feature" type="flexberry:layerType"/>` +
+      `</xsd:schema>`;
 
-  let describeFeatureTypeResponse = `` +
-    `<?xml version="1.0" encoding="UTF-8"?>` +
-    `<xsd:schema xmlns:gml="http://www.opengis.net/gml" ` +
-    `xmlns:flexberry="http://flexberry.ru" ` +
-    `xmlns:xsd="http://www.w3.org/2001/XMLSchema" ` +
-    `elementFormDefault="qualified" ` +
-    `targetNamespace="http://flexberry.ru">` +
-    `<xsd:import namespace="http://www.opengis.net/gml" schemaLocation="http://flexberry.ru/schemas/gml/3.1.1/base/gml.xsd"/>` +
-    `<xsd:complexType name="layerType">` +
-    `<xsd:complexContent>` +
-    `<xsd:extension base="gml:AbstractFeatureType">` +
-    `<xsd:sequence>` +
-    `${layerPropertiesDescription}` +
-    `<xsd:element maxOccurs="1" minOccurs="0" name="${geometryField}" nillable="true" type="gml:GeometryPropertyType"/>` +
-    `</xsd:sequence>` +
-    `</xsd:extension>` +
-    `</xsd:complexContent>` +
-    `</xsd:complexType>` +
-    `<xsd:element name="layer" substitutionGroup="gml:_Feature" type="flexberry:layerType"/>` +
-    `</xsd:schema>`;
+    let describeFeatureTypeXml = L.XmlUtil.parseXml(describeFeatureTypeResponse);
+    let featureInfo = describeFeatureTypeXml.documentElement;
+    readFormat.setFeatureDescription(featureInfo);
+    readFormat.excludedProperties = [];
 
-  let describeFeatureTypeXml = L.XmlUtil.parseXml(describeFeatureTypeResponse);
-  let featureInfo = describeFeatureTypeXml.documentElement;
-  readFormat.setFeatureDescription(featureInfo);
-  readFormat.excludedProperties = [];
+    return readFormat;
+  },
 
-  return readFormat;
-},
+  /**
+    Clusterizes created vector layer if 'clusterize' option is enabled.
 
-/**
-  Clusterizes created vector layer if 'clusterize' option is enabled.
+    @method createClusterLayer
+    @param {<a href="http://leafletjs.com/reference-1.0.1.html#layer">L.Layer</a>} vectorLayer Vector layer which must be clusterized.
+    @return {<a href="https://github.com/Leaflet/Leaflet.markercluster/blob/master/src/MarkerClusterGroup.js">L.MarkerClusterGroup</a>} Clusterized vector layer.
+  */
+  createClusterLayer(vectorLayer) {
+    let clusterLayer = L.markerClusterGroup(this.get('clusterOptions'));
 
-  @method createClusterLayer
-  @param {<a href="http://leafletjs.com/reference-1.0.1.html#layer">L.Layer</a>} vectorLayer Vector layer which must be clusterized.
-  @return {<a href="https://github.com/Leaflet/Leaflet.markercluster/blob/master/src/MarkerClusterGroup.js">L.MarkerClusterGroup</a>} Clusterized vector layer.
-*/
-createClusterLayer(vectorLayer) {
-  let clusterLayer = L.markerClusterGroup(this.get('clusterOptions'));
+    // Original vector layer is necessary for 'flexberry-layers-attributes-panel' component and identification map tool
+    clusterLayer._originalVectorLayer = vectorLayer;
 
-  // Original vector layer is necessary for 'flexberry-layers-attributes-panel' component and identification map tool
-  clusterLayer._originalVectorLayer = vectorLayer;
+    // Features loading of original vectorLayer does not trigger parent's clusterLayer.addLayer(), link explicitly
+    clusterLayer._originalVectorLayer.on('layeradd', this.loadClusterLayer, this);
+    clusterLayer._originalVectorLayer.on('layerremove', this.loadClusterLayer, this);
 
-  // Features loading of original vectorLayer does not trigger parent's clusterLayer.addLayer(), link explicitly
-  clusterLayer._originalVectorLayer.on('layeradd', this.loadClusterLayer, this);
-  clusterLayer._originalVectorLayer.on('layerremove', this.loadClusterLayer, this);
+    // Apply display settings for clustered features.
+    clusterLayer._featureGroup.on('layeradd', this.updateClusterLayer, this);
+    clusterLayer._featureGroup.on('layerremove', this.updateClusterLayer, this);
 
-  // Apply display settings for clustered features.
-  clusterLayer._featureGroup.on('layeradd', this.updateClusterLayer, this);
-  clusterLayer._featureGroup.on('layerremove', this.updateClusterLayer, this);
+    clusterLayer.addLayer(vectorLayer);
 
-  clusterLayer.addLayer(vectorLayer);
+    return clusterLayer;
+  },
+  /**
+    Apply display settings for clustered objects. Updating the visibility of the feature labels, opacity.
 
-  return clusterLayer;
-},
-/**
-  Apply display settings for clustered objects. Updating the visibility of the feature labels, opacity.
+    @method updateClusterLayer
+    @param {Object} e action context.
+  */
+  updateClusterLayer(e) {
+    this._setLayerOpacity();
 
-  @method updateClusterLayer
-  @param {Object} e action context.
-*/
-updateClusterLayer(e) {
-  this._setLayerOpacity();
+    if (!e || !e.layer || !e.type) {
+      return;
+    }
 
-  if (!e || !e.layer || !e.type) {
-    return;
-  }
+    if (e.layer instanceof L.MarkerCluster) {
+      return;
+    }
 
-  if (e.layer instanceof L.MarkerCluster) {
-    return;
-  }
+    let leafletMap = this.get('leafletMap');
+    let layerLabel = e.layer._label;
 
-  let leafletMap = this.get('leafletMap');
-  let layerLabel = e.layer._label;
-
-  if (e.type === 'layeradd') {
-    this._setLayerStyle();
-  }
-
-  if (layerLabel) {
     if (e.type === 'layeradd') {
-      layerLabel.forEach(label => {
-        if (!leafletMap.hasLayer(label)) {
-          leafletMap.addLayer(label);
-        }
-      });
-    } else {
-      layerLabel.forEach(label => {
-        if (leafletMap.hasLayer(label)) {
-          leafletMap.removeLayer(label);
-        }
-      });
+      this._setLayerStyle();
     }
-  }
-},
 
-/**
-  Synchronizes ClusterLayer._originalVectorLayer._layers with ClusterLayer layers.
-  This is required when continueLoading option.
-
-  @method loadClusterLayer
-  @param {Object} e action context.
-*/
-loadClusterLayer(e) {
-  if (!e || !e.layer) {
-    return;
-  }
-
-  if (e.type === 'layeradd') {
-    Ember.run.once(this, 'addClusterLayer', e);
-    return;
-  }
-
-  let clusterLayer = this.get('_leafletObject');
-  if (!(clusterLayer instanceof L.MarkerClusterGroup)) {
-    return;
-  }
-
-  clusterLayer.removeLayer(e.layer);
-},
-
-/**
-  Adds ClusterLayer layers.
-
-  @method addClusterLayer
-  @param {Object} e action context.
-*/
-addClusterLayer(e) {
-  if (!e || !e.target) {
-    console.error('Unable to update clusterLayer');
-    return;
-  }
-
-  let clusterLayer = this.get('_leafletObject');
-  let leafletMap = this.get('leafletMap');
-  if (!(clusterLayer instanceof L.MarkerClusterGroup)) {
-    return;
-  }
-
-  let updatedOriginalVectorLayer = e.target;
-  clusterLayer.addLayer(updatedOriginalVectorLayer);
-
-  // L.MarkerClusterGroup includes both child L.MarkerCluster and L.Marker in _featureGroup after originalVectorLayer addition
-  let clusterMarkers = clusterLayer._featureGroup.getLayers().filter(layer => layer instanceof L.MarkerCluster);
-
-  clusterMarkers.forEach(clusterMarker => {
-    // For L.MarkerCluster there is an option to get clustered markers
-    clusterMarker.getAllChildMarkers()
-      .filter(markerLayer => {
-        if (Ember.isNone(markerLayer._label) || !Ember.isArray(markerLayer._label)) {
-          return false;
-        }
-
-        return markerLayer._label.some(label => {
-          return leafletMap.hasLayer(label);
-        });
-      })
-      .map(markerLayerWithLabel => {
-        markerLayerWithLabel._label.forEach(label => {
-          leafletMap.removeLayer(label);
-        });
-      });
-  });
-
-  this._setLayerState(); // Accept layer style options for new loaded features
-},
-
-/**
-  Destroys clusterized leaflet layer related to layer type.
-
-  @method destroyLayer
-*/
-destroyClusterLayer(clusterLayer) {
-  clusterLayer._featureGroup.off('layeradd', this.updateClusterLayer, this);
-  clusterLayer._featureGroup.off('layerremove', this.updateClusterLayer, this);
-  clusterLayer._originalVectorLayer.off('layeradd', this.loadClusterLayer, this);
-  clusterLayer._originalVectorLayer.off('layerremove', this.loadClusterLayer, this);
-},
-
-/*
-  Get the field to search for objects
-  @method getPkField
-  @param {Object} layer.
-  @return {String} Field name.
-*/
-getPkField(layer) {
-  const getPkField = this.get('mapApi').getFromApi('getPkField');
-  if (typeof getPkField === 'function') {
-    return getPkField(layer);
-  }
-
-  let field = Ember.get(layer, 'settingsAsObject.pkField');
-  return Ember.isNone(field) ? 'primarykey' : field;
-},
-
-/**
-  Show all layer objects.
-  @method showAllLayerObjects
-  @return {Promise}
-*/
-showAllLayerObjects() {
-  return new Ember.RSVP.Promise((resolve, reject) => {
-    let leafletObject = this.returnLeafletObject();
-    let map = this.get('leafletMap');
-    let layer = this.get('layerModel');
-
-    let continueLoading = leafletObject.options.continueLoading;
-    if (!continueLoading) {
-      if (!Ember.isNone(leafletObject)) {
-        leafletObject.eachLayer((layerShape) => {
-          if (map.hasLayer(layerShape)) {
-            map.removeLayer(layerShape);
+    if (layerLabel) {
+      if (e.type === 'layeradd') {
+        layerLabel.forEach(label => {
+          if (!leafletMap.hasLayer(label)) {
+            leafletMap.addLayer(label);
           }
         });
-        if (!leafletObject.options.showExisting) {
-          leafletObject.clearLayers();
-        }
-      }
-
-      leafletObject.promiseLoadLayer = new Ember.RSVP.Promise((resolve) => {
-        let e = {
-          featureIds: null
-        };
-
-        leafletObject.loadLayerFeatures(e).then(() => {
-          resolve('Features loaded');
+      } else {
+        layerLabel.forEach(label => {
+          if (leafletMap.hasLayer(label)) {
+            leafletMap.removeLayer(label);
+          }
         });
-      });
-    } else {
-      leafletObject.showLayerObjects = true;
-      leafletObject.statusLoadLayer = true;
-
-      this.continueLoad(leafletObject);
-      if (Ember.isNone(leafletObject.promiseLoadLayer) || !(leafletObject.promiseLoadLayer instanceof Ember.RSVP.Promise)) {
-        leafletObject.promiseLoadLayer = Ember.RSVP.resolve();
       }
     }
+  },
 
-    leafletObject.promiseLoadLayer.then(() => {
-      leafletObject.statusLoadLayer = false;
-      leafletObject.promiseLoadLayer = null;
-      leafletObject.eachLayer(function (layerShape) {
-        if (!map.hasLayer(layerShape)) {
-          map.addLayer(layerShape);
-        }
-      });
+  /**
+    Synchronizes ClusterLayer._originalVectorLayer._layers with ClusterLayer layers.
+    This is required when continueLoading option.
 
-      this.showAllLayerObjectsLabel(leafletObject, layer);
-
-      resolve('success');
-    });
-  });
-},
-
-/**
-  Hide all layer objects.
-  @method hideAllLayerObjects
-  @return nothing
-*/
-hideAllLayerObjects() {
-  let leafletObject = this.returnLeafletObject();
-  let map = this.get('leafletMap');
-  let layer = this.get('layerModel');
-
-  leafletObject.showLayerObjects = false;
-
-  leafletObject.eachLayer(function (layerShape) {
-    if (map.hasLayer(layerShape)) {
-      map.removeLayer(layerShape);
+    @method loadClusterLayer
+    @param {Object} e action context.
+  */
+  loadClusterLayer(e) {
+    if (!e || !e.layer) {
+      return;
     }
-  });
 
-  this.hideAllLayerObjectsLabel(leafletObject, layer);
-},
+    if (e.type === 'layeradd') {
+      Ember.run.once(this, 'addClusterLayer', e);
+      return;
+    }
 
-/**
-  Determine the visibility of the specified objects by id for the layer.
-  @method _setVisibilityObjects
-  @param {string[]} objectIds Array of objects IDs.
-  @param {boolean} [visibility=false] visibility Object Visibility.
-  @return {Ember.RSVP.Promise}
-*/
-_setVisibilityObjects(objectIds, visibility = false) {
-  return new Ember.RSVP.Promise((resolve, reject) => {
-    let leafletObject = this.returnLeafletObject();
-    let map = this.get('leafletMap');
-    let layer = this.get('layerModel');
+    let clusterLayer = this.get('_leafletObject');
+    if (!(clusterLayer instanceof L.MarkerClusterGroup)) {
+      return;
+    }
 
-    if (visibility) {
+    clusterLayer.removeLayer(e.layer);
+  },
+
+  /**
+    Adds ClusterLayer layers.
+
+    @method addClusterLayer
+    @param {Object} e action context.
+  */
+  addClusterLayer(e) {
+    if (!e || !e.target) {
+      console.error('Unable to update clusterLayer');
+      return;
+    }
+
+    let clusterLayer = this.get('_leafletObject');
+    let leafletMap = this.get('leafletMap');
+    if (!(clusterLayer instanceof L.MarkerClusterGroup)) {
+      return;
+    }
+
+    let updatedOriginalVectorLayer = e.target;
+    clusterLayer.addLayer(updatedOriginalVectorLayer);
+
+    // L.MarkerClusterGroup includes both child L.MarkerCluster and L.Marker in _featureGroup after originalVectorLayer addition
+    let clusterMarkers = clusterLayer._featureGroup.getLayers().filter(layer => layer instanceof L.MarkerCluster);
+
+    clusterMarkers.forEach(clusterMarker => {
+      // For L.MarkerCluster there is an option to get clustered markers
+      clusterMarker.getAllChildMarkers()
+        .filter(markerLayer => {
+          if (Ember.isNone(markerLayer._label) || !Ember.isArray(markerLayer._label)) {
+            return false;
+          }
+
+          return markerLayer._label.some(label => {
+            return leafletMap.hasLayer(label);
+          });
+        })
+        .map(markerLayerWithLabel => {
+          markerLayerWithLabel._label.forEach(label => {
+            leafletMap.removeLayer(label);
+          });
+        });
+    });
+
+    this._setLayerState(); // Accept layer style options for new loaded features
+  },
+
+  /**
+    Destroys clusterized leaflet layer related to layer type.
+
+    @method destroyLayer
+  */
+  destroyClusterLayer(clusterLayer) {
+    clusterLayer._featureGroup.off('layeradd', this.updateClusterLayer, this);
+    clusterLayer._featureGroup.off('layerremove', this.updateClusterLayer, this);
+    clusterLayer._originalVectorLayer.off('layeradd', this.loadClusterLayer, this);
+    clusterLayer._originalVectorLayer.off('layerremove', this.loadClusterLayer, this);
+  },
+
+  /*
+    Get the field to search for objects
+    @method getPkField
+    @param {Object} layer.
+    @return {String} Field name.
+  */
+  getPkField(layer) {
+    const getPkField = this.get('mapApi').getFromApi('getPkField');
+    if (typeof getPkField === 'function') {
+      return getPkField(layer);
+    }
+
+    let field = Ember.get(layer, 'settingsAsObject.pkField');
+    return Ember.isNone(field) ? 'primarykey' : field;
+  },
+
+  /**
+    Show all layer objects.
+    @method showAllLayerObjects
+    @return {Promise}
+  */
+  showAllLayerObjects() {
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      let leafletObject = this.returnLeafletObject();
+      let map = this.get('leafletMap');
+      let layer = this.get('layerModel');
+
       let continueLoading = leafletObject.options.continueLoading;
       if (!continueLoading) {
+        if (!Ember.isNone(leafletObject)) {
+          leafletObject.eachLayer((layerShape) => {
+            if (map.hasLayer(layerShape)) {
+              map.removeLayer(layerShape);
+            }
+          });
+          if (!leafletObject.options.showExisting) {
+            leafletObject.clearLayers();
+          }
+        }
+
         leafletObject.promiseLoadLayer = new Ember.RSVP.Promise((resolve) => {
           let e = {
-            featureIds: objectIds
+            featureIds: null
           };
 
           leafletObject.loadLayerFeatures(e).then(() => {
@@ -630,723 +558,795 @@ _setVisibilityObjects(objectIds, visibility = false) {
           });
         });
       } else {
-        reject('Not working to layer with continueLoading');
+        leafletObject.showLayerObjects = true;
+        leafletObject.statusLoadLayer = true;
+
+        this.continueLoad(leafletObject);
+        if (Ember.isNone(leafletObject.promiseLoadLayer) || !(leafletObject.promiseLoadLayer instanceof Ember.RSVP.Promise)) {
+          leafletObject.promiseLoadLayer = Ember.RSVP.resolve();
+        }
       }
-    } else {
-      leafletObject.promiseLoadLayer = Ember.RSVP.resolve();
-    }
 
-    leafletObject.promiseLoadLayer.then(() => {
-      leafletObject.statusLoadLayer = false;
-      leafletObject.promiseLoadLayer = null;
-      objectIds.forEach(objectId => {
-        let objects = Object.values(leafletObject._layers).filter(shape => {
-          return this.get('mapApi').getFromApi('mapModel')._getLayerFeatureId(layer, shape) === objectId;
+      leafletObject.promiseLoadLayer.then(() => {
+        leafletObject.statusLoadLayer = false;
+        leafletObject.promiseLoadLayer = null;
+        leafletObject.eachLayer(function (layerShape) {
+          if (!map.hasLayer(layerShape)) {
+            map.addLayer(layerShape);
+          }
         });
-        if (objects.length > 0) {
-          objects.forEach(obj => {
-            if (visibility) {
-              map.addLayer(obj);
-            } else {
-              map.removeLayer(obj);
-            }
-          });
-        }
+
+        this.showAllLayerObjectsLabel(leafletObject, layer);
+
+        resolve('success');
       });
-
-      this._setVisibilityObjectsLabel(leafletObject, layer, objectIds, visibility);
-
-      resolve('success');
     });
-  });
-},
+  },
 
-/**
-  Get nearest object.
-  Gets all leaflet layer objects and processes them _calcNearestObject().
+  /**
+    Hide all layer objects.
+    @method hideAllLayerObjects
+    @return nothing
+  */
+  hideAllLayerObjects() {
+    let leafletObject = this.returnLeafletObject();
+    let map = this.get('leafletMap');
+    let layer = this.get('layerModel');
 
-  @method getNearObject
-  @param {Object} e Event object..
-  @param {Object} featureLayer Leaflet layer object.
-  @param {Number} featureId Leaflet layer object id.
-  @param {Number} layerObjectId Leaflet layer id.
-  @return {Ember.RSVP.Promise} Returns object with distance, layer model and nearest leaflet layer object.
-*/
-getNearObject(e) {
-  return new Ember.RSVP.Promise((resolve, reject) => {
-    let features = {
-      featureIds: null
-    };
-    this.getLayerFeatures(features)
-      .then((featuresLayer) => {
-        if (Ember.isArray(featuresLayer) && featuresLayer.length > 0) {
-          resolve(this._calcNearestObject(featuresLayer, e));
+    leafletObject.showLayerObjects = false;
+
+    leafletObject.eachLayer(function (layerShape) {
+      if (map.hasLayer(layerShape)) {
+        map.removeLayer(layerShape);
+      }
+    });
+
+    this.hideAllLayerObjectsLabel(leafletObject, layer);
+  },
+
+  /**
+    Determine the visibility of the specified objects by id for the layer.
+    @method _setVisibilityObjects
+    @param {string[]} objectIds Array of objects IDs.
+    @param {boolean} [visibility=false] visibility Object Visibility.
+    @return {Ember.RSVP.Promise}
+  */
+  _setVisibilityObjects(objectIds, visibility = false) {
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      let leafletObject = this.returnLeafletObject();
+      let map = this.get('leafletMap');
+      let layer = this.get('layerModel');
+
+      if (visibility) {
+        let continueLoading = leafletObject.options.continueLoading;
+        if (!continueLoading) {
+          leafletObject.promiseLoadLayer = new Ember.RSVP.Promise((resolve) => {
+            let e = {
+              featureIds: objectIds
+            };
+
+            leafletObject.loadLayerFeatures(e).then(() => {
+              resolve('Features loaded');
+            });
+          });
         } else {
-          resolve('Nearest object not found');
+          reject('Not working to layer with continueLoading');
         }
-      })
-      .catch((error) => {
-        reject(error);
+      } else {
+        leafletObject.promiseLoadLayer = Ember.RSVP.resolve();
+      }
+
+      leafletObject.promiseLoadLayer.then(() => {
+        leafletObject.statusLoadLayer = false;
+        leafletObject.promiseLoadLayer = null;
+        objectIds.forEach(objectId => {
+          let objects = Object.values(leafletObject._layers).filter(shape => {
+            return this.get('mapApi').getFromApi('mapModel')._getLayerFeatureId(layer, shape) === objectId;
+          });
+          if (objects.length > 0) {
+            objects.forEach(obj => {
+              if (visibility) {
+                map.addLayer(obj);
+              } else {
+                map.removeLayer(obj);
+              }
+            });
+          }
+        });
+
+        this._setVisibilityObjectsLabel(leafletObject, layer, objectIds, visibility);
+
+        resolve('success');
       });
-  });
-},
+    });
+  },
 
-/**
-  Calculates nearest object.
-  Iterates all objects and calculates min distance. If it searches for nearest object in same layer, it is excluded e.featureLayer.
+  /**
+    Get nearest object.
+    Gets all leaflet layer objects and processes them _calcNearestObject().
 
-  @method getNearObject
-  @param {Array} featuresLayer Leaflet layer objects.
-  @param {Object} e Event object..
-  @param {Object} featureLayer Leaflet layer object.
-  @param {Number} featureId Leaflet layer object id.
-  @param {Number} layerObjectId Leaflet layer id.
-  @return {Ember.RSVP.Promise} Returns object with distance, layer model and nearest leaflet layer object.
-*/
-_calcNearestObject(featuresLayer, e) {
-  let result = null;
-  let mapApi = this.get('mapApi').getFromApi('mapModel');
-  let layerModel = this.get('layerModel');
-  let layerId = layerModel.get('id');
-  featuresLayer.forEach(obj => {
-    let leafletLayer = Ember.isNone(obj.leafletLayer) ? obj : obj.leafletLayer;
-    const id = mapApi._getLayerFeatureId(layerModel, leafletLayer);
-    if (layerId === e.layerObjectId && e.featureId === id) {
+    @method getNearObject
+    @param {Object} e Event object..
+    @param {Object} featureLayer Leaflet layer object.
+    @param {Number} featureId Leaflet layer object id.
+    @param {Number} layerObjectId Leaflet layer id.
+    @return {Ember.RSVP.Promise} Returns object with distance, layer model and nearest leaflet layer object.
+  */
+  getNearObject(e) {
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      let features = {
+        featureIds: null
+      };
+      this.getLayerFeatures(features)
+        .then((featuresLayer) => {
+          if (Ember.isArray(featuresLayer) && featuresLayer.length > 0) {
+            resolve(this._calcNearestObject(featuresLayer, e));
+          } else {
+            resolve('Nearest object not found');
+          }
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    });
+  },
+
+  /**
+    Calculates nearest object.
+    Iterates all objects and calculates min distance. If it searches for nearest object in same layer, it is excluded e.featureLayer.
+
+    @method getNearObject
+    @param {Array} featuresLayer Leaflet layer objects.
+    @param {Object} e Event object..
+    @param {Object} featureLayer Leaflet layer object.
+    @param {Number} featureId Leaflet layer object id.
+    @param {Number} layerObjectId Leaflet layer id.
+    @return {Ember.RSVP.Promise} Returns object with distance, layer model and nearest leaflet layer object.
+  */
+  _calcNearestObject(featuresLayer, e) {
+    let result = null;
+    let mapApi = this.get('mapApi').getFromApi('mapModel');
+    let layerModel = this.get('layerModel');
+    let layerId = layerModel.get('id');
+    featuresLayer.forEach(obj => {
+      let leafletLayer = Ember.isNone(obj.leafletLayer) ? obj : obj.leafletLayer;
+      const id = mapApi._getLayerFeatureId(layerModel, leafletLayer);
+      if (layerId === e.layerObjectId && e.featureId === id) {
+        return;
+      }
+
+      const distance = mapApi._getDistanceBetweenObjects(e.featureLayer, leafletLayer);
+      if (Ember.isNone(result) || distance < result.distance) {
+        result = {
+          distance: distance,
+          layer: layerModel,
+          object: leafletLayer,
+        };
+      }
+    });
+    return result;
+  },
+
+  /**
+    Creates leaflet layer related to layer type.
+
+    @method createLayer
+    @return {<a href="http://leafletjs.com/reference-1.0.1.html#layer">L.Layer</a>|<a href="https://emberjs.com/api/classes/RSVP.Promise.html">Ember.RSVP.Promise</a>}
+    Leaflet layer or promise returning such layer.
+  */
+  createLayer() {
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      Ember.RSVP.hash({
+        vectorLayer: this.createVectorLayer()
+      }).then(({ vectorLayer }) => {
+        // Read format contains 'DescribeFeatureType' metadata and is necessary for 'flexberry-layers-attributes-panel' component.
+        let readFormat = vectorLayer.readFormat;
+        if (Ember.isNone(readFormat)) {
+          // For combine layer
+          if (!Ember.isNone(this.dynamicProperties) && !Ember.isNone(this.dynamicProperties.type)) {
+            vectorLayer.type = this.dynamicProperties.type;
+          }
+
+          vectorLayer.readFormat = this.createReadFormat(vectorLayer);
+        }
+
+        vectorLayer.minZoom = this.get('minZoom');
+        vectorLayer.maxZoom = this.get('maxZoom');
+
+        vectorLayer.getContainer = this.get('_getContainer').bind(this);
+        vectorLayer.getPkField = this.get('getPkField').bind(this);
+        vectorLayer.showAllLayerObjects = this.get('showAllLayerObjects').bind(this);
+        vectorLayer.hideAllLayerObjects = this.get('hideAllLayerObjects').bind(this);
+        vectorLayer._setVisibilityObjects = this.get('_setVisibilityObjects').bind(this);
+
+        // change style by change zoom
+        let styleRules = this.get('layerModel.settingsAsObject.styleRules');
+        if (styleRules && styleRules.length > 0) {
+          this.set('styleRules', styleRules);
+          this.set('layerModel.styleRules', styleRules);
+          this._updateStyleRules();
+          this.get('leafletMap').on('zoomend', this._updateStyleRules, this);
+        }
+
+        // load images for style
+        let imagePromises = Ember.A();
+        let styleSettings = this.get('layerModel.settingsAsObject.styleSettings');
+        if (!Ember.isNone(styleRules) && styleRules.length > 0) {
+          this._imageFromStyleRules(imagePromises);
+        } else if (!Ember.isNone(styleSettings)) {
+          this._imageFromStyleSettings(imagePromises, styleSettings);
+        }
+
+        if (Ember.isNone(vectorLayer.loadLayerFeatures)) {
+          Ember.set(vectorLayer, 'loadLayerFeatures', this.loadLayerFeatures.bind(this));
+        }
+
+        let resultLayer = vectorLayer;
+        if (this.get('clusterize')) {
+          let clusterLayer = this.createClusterLayer(vectorLayer);
+          resultLayer = clusterLayer;
+        }
+
+        if (imagePromises.length > 0) {
+          Ember.RSVP.allSettled(imagePromises).then((styles) => {
+            styles.forEach(style => {
+              for (let property in style.value) {
+                if (!Ember.isNone(style.value[property].tagName)) {
+                  styleSettings.style.path[property].imagePattern = style.value[property];
+                } else {
+                  for (let propertyInner in style.value[property]) {
+                    styleRules[property].styleSettings.style.path[propertyInner].imagePattern = style.value[property][propertyInner];
+                  }
+                }
+              }
+            });
+            resolve(resultLayer);
+          });
+        } else {
+          resolve(resultLayer);
+        }
+      }).catch((e) => {
+        reject(e);
+      });
+    });
+  },
+
+  /**
+    Add in array promise which load pattern from styleSettings.
+
+    @method _imageFromStyleSettings
+  */
+  _imageFromStyleSettings(imagePromises, styleSettings, index) {
+    if (styleSettings.style.path) {
+      if (Ember.isArray(styleSettings.style.path)) {
+        styleSettings.style.path.forEach((style, i) => {
+          if (style.fillStyle === 'pattern') {
+            imagePromises.addObject(this._setPattern(style, i, index));
+          }
+        });
+      } else if (styleSettings.style.path.fillStyle === 'pattern') {
+        imagePromises.addObject(this._setPattern(styleSettings.style.path, 0, index));
+      }
+    }
+  },
+
+  /**
+    For each styleRules load pattern.
+
+    @method _imageFromStyleRules
+  */
+  _imageFromStyleRules(imagePromises) {
+    let styleRules = this.get('styleRules');
+    if (Ember.isNone(styleRules)) {
       return;
     }
 
-    const distance = mapApi._getDistanceBetweenObjects(e.featureLayer, leafletLayer);
-    if (Ember.isNone(result) || distance < result.distance) {
-      result = {
-        distance: distance,
-        layer: layerModel,
-        object: leafletLayer,
-      };
+    styleRules.forEach((styleRule, i) => {
+      this._imageFromStyleSettings(imagePromises, styleRule.styleSettings, i);
+    });
+  },
+
+  /**
+    Change styleSettings depending on the zoom.
+
+    @method _updateStyleRules
+  */
+  _updateStyleRules() {
+    let styleRules = this.get('styleRules');
+    if (Ember.isNone(styleRules)) {
+      return;
     }
-  });
-  return result;
-},
 
-/**
-  Creates leaflet layer related to layer type.
+    let leafletMap = this.get('leafletMap');
+    styleRules.forEach(styleRule => {
+      let rule = styleRule.rule;
+      let caption = `${this.get('i18n').t('components.base-vector-layer.zoomFrom').string} ${rule.minZoom}
+        ${this.get('i18n').t('components.base-vector-layer.zoomTo').string} ${rule.maxZoom}`;
+      Ember.set(rule, 'caption', caption);
+      if (checkMapZoomStyle(leafletMap, styleRule.rule) && this.get('styleSettings') !== styleRule.styleSettings) {
+        this.set('styleSettings', styleRule.styleSettings);
+      }
+    });
+  },
 
-  @method createLayer
-  @return {<a href="http://leafletjs.com/reference-1.0.1.html#layer">L.Layer</a>|<a href="https://emberjs.com/api/classes/RSVP.Promise.html">Ember.RSVP.Promise</a>}
-  Leaflet layer or promise returning such layer.
-*/
-createLayer() {
-  return new Ember.RSVP.Promise((resolve, reject) => {
-    Ember.RSVP.hash({
-      vectorLayer: this.createVectorLayer()
-    }).then(({ vectorLayer }) => {
-      // Read format contains 'DescribeFeatureType' metadata and is necessary for 'flexberry-layers-attributes-panel' component.
-      let readFormat = vectorLayer.readFormat;
-      if (Ember.isNone(readFormat)) {
-        // For combine layer
-        if (!Ember.isNone(this.dynamicProperties) && !Ember.isNone(this.dynamicProperties.type)) {
-          vectorLayer.type = this.dynamicProperties.type;
+  /**
+    Load image for pattern.
+
+    @method _setPattern
+  */
+  _setPattern(style, i, index = null) {
+    return new Ember.RSVP.Promise((resolve) => {
+      let image = new Image();
+      Ember.set(style, 'pattern', true);
+      image.onload = function () {
+        Ember.set(style, 'imagePattern', this);
+        let result = {};
+        if (Ember.isNone(index)) {
+          result[i] = this;
+        } else {
+          let inner = {};
+          inner[i] = this;
+          result[index] = inner;
         }
 
-        vectorLayer.readFormat = this.createReadFormat(vectorLayer);
-      }
+        return resolve(result);
+      };
 
-      vectorLayer.minZoom = this.get('minZoom');
-      vectorLayer.maxZoom = this.get('maxZoom');
+      image.src = style.fillPattern;
+    });
+  },
 
-      vectorLayer.getContainer = this.get('_getContainer').bind(this);
-      vectorLayer.getPkField = this.get('getPkField').bind(this);
-      vectorLayer.showAllLayerObjects = this.get('showAllLayerObjects').bind(this);
-      vectorLayer.hideAllLayerObjects = this.get('hideAllLayerObjects').bind(this);
-      vectorLayer._setVisibilityObjects = this.get('_setVisibilityObjects').bind(this);
+  /**
+    Destroys leaflet layer related to layer type.
 
-      // change style by change zoom
-      let styleRules = this.get('layerModel.settingsAsObject.styleRules');
-      if (styleRules && styleRules.length > 0) {
-        this.set('styleRules', styleRules);
-        this.set('layerModel.styleRules', styleRules);
-        this._updateStyleRules();
-        this.get('leafletMap').on('zoomend', this._updateStyleRules, this);
-      }
+    @method destroyLayer
+  */
+  destroyLayer() {
+    let leafletLayer = this.get('_leafletObject');
+    if (leafletLayer instanceof L.MarkerClusterGroup) {
+      this.destroyClusterLayer(leafletLayer);
+    }
+  },
 
-      // load images for style
-      let imagePromises = Ember.A();
-      let styleSettings = this.get('layerModel.settingsAsObject.styleSettings');
-      if (!Ember.isNone(styleRules) && styleRules.length > 0) {
-        this._imageFromStyleRules(imagePromises);
-      } else if (!Ember.isNone(styleSettings)) {
-        this._imageFromStyleSettings(imagePromises, styleSettings);
-      }
+  /**
+    Handles 'flexberry-map:identify' event of leaflet map.
 
-      if (Ember.isNone(vectorLayer.loadLayerFeatures)) {
-        Ember.set(vectorLayer, 'loadLayerFeatures', this.loadLayerFeatures.bind(this));
-      }
+    @method identify
+    @param {Object} e Event object.
+    @param {<a href="http://leafletjs.com/reference.html#polygon">L.Polygon</a>} polygonLayer Polygon layer related to given area.
+    @param {Object[]} layers Objects describing those layers which must be identified.
+    @param {Object[]} results Objects describing identification results.
+    Every result-object has the following structure: { layer: ..., features: [...] },
+    where 'layer' is metadata of layer related to identification result, features is array
+    containing (GeoJSON feature-objects)[http://geojson.org/geojson-spec.html#feature-objects]
+    or a promise returning such array.
+  */
+  identify(e) {
+    let primitiveSatisfiesBounds = (primitive, bounds) => {
+      let satisfiesBounds = false;
 
-      let resultLayer = vectorLayer;
-      if (this.get('clusterize')) {
-        let clusterLayer = this.createClusterLayer(vectorLayer);
-        resultLayer = clusterLayer;
-      }
+      if (typeof primitive.forEach === 'function') {
+        primitive.forEach(function (nestedGeometry, index) {
+          if (satisfiesBounds) {
+            return;
+          }
 
-      if (imagePromises.length > 0) {
-        Ember.RSVP.allSettled(imagePromises).then((styles) => {
-          styles.forEach(style => {
-            for (let property in style.value) {
-              if (!Ember.isNone(style.value[property].tagName)) {
-                styleSettings.style.path[property].imagePattern = style.value[property];
-              } else {
-                for (let propertyInner in style.value[property]) {
-                  styleRules[property].styleSettings.style.path[propertyInner].imagePattern = style.value[property][propertyInner];
-                }
-              }
-            }
-          });
-          resolve(resultLayer);
+          let nestedPrimitive = this.get(index);
+          satisfiesBounds = primitiveSatisfiesBounds(nestedPrimitive, bounds);
         });
       } else {
-        resolve(resultLayer);
-      }
-    }).catch((e) => {
-      reject(e);
-    });
-  });
-},
-
-/**
-  Add in array promise which load pattern from styleSettings.
-
-  @method _imageFromStyleSettings
-*/
-_imageFromStyleSettings(imagePromises, styleSettings, index) {
-  if (styleSettings.style.path) {
-    if (Ember.isArray(styleSettings.style.path)) {
-      styleSettings.style.path.forEach((style, i) => {
-        if (style.fillStyle === 'pattern') {
-          imagePromises.addObject(this._setPattern(style, i, index));
-        }
-      });
-    } else if (styleSettings.style.path.fillStyle === 'pattern') {
-      imagePromises.addObject(this._setPattern(styleSettings.style.path, 0, index));
-    }
-  }
-},
-
-/**
-  For each styleRules load pattern.
-
-  @method _imageFromStyleRules
-*/
-_imageFromStyleRules(imagePromises) {
-  let styleRules = this.get('styleRules');
-  if (Ember.isNone(styleRules)) {
-    return;
-  }
-
-  styleRules.forEach((styleRule, i) => {
-    this._imageFromStyleSettings(imagePromises, styleRule.styleSettings, i);
-  });
-},
-
-/**
-  Change styleSettings depending on the zoom.
-
-  @method _updateStyleRules
-*/
-_updateStyleRules() {
-  let styleRules = this.get('styleRules');
-  if (Ember.isNone(styleRules)) {
-    return;
-  }
-
-  let leafletMap = this.get('leafletMap');
-  styleRules.forEach(styleRule => {
-    let rule = styleRule.rule;
-    let caption = `${this.get('i18n').t('components.base-vector-layer.zoomFrom').string} ${rule.minZoom}
-        ${this.get('i18n').t('components.base-vector-layer.zoomTo').string} ${rule.maxZoom}`;
-    Ember.set(rule, 'caption', caption);
-    if (checkMapZoomStyle(leafletMap, styleRule.rule) && this.get('styleSettings') !== styleRule.styleSettings) {
-      this.set('styleSettings', styleRule.styleSettings);
-    }
-  });
-},
-
-/**
-  Load image for pattern.
-
-  @method _setPattern
-*/
-_setPattern(style, i, index = null) {
-  return new Ember.RSVP.Promise((resolve) => {
-    let image = new Image();
-    Ember.set(style, 'pattern', true);
-    image.onload = function () {
-      Ember.set(style, 'imagePattern', this);
-      let result = {};
-      if (Ember.isNone(index)) {
-        result[i] = this;
-      } else {
-        let inner = {};
-        inner[i] = this;
-        result[index] = inner;
+        satisfiesBounds = primitive.within(bounds) || primitive.intersects(bounds);
       }
 
-      return resolve(result);
+      return satisfiesBounds;
     };
 
-    image.src = style.fillPattern;
-  });
-},
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      try {
+        let features = Ember.A();
+        let bounds = new Terraformer.Primitive(e.polygonLayer.toGeoJSON());
+        let leafletLayer = this.returnLeafletObject();
+        let mapModel = this.get('mapApi').getFromApi('mapModel');
+        let scale = this.get('mapApi').getFromApi('precisionScale');
+        leafletLayer.eachLayer(function (layer) {
+          let geoLayer = layer.toGeoJSON();
+          let primitive = new Terraformer.Primitive(geoLayer.geometry);
 
-/**
-  Destroys leaflet layer related to layer type.
-
-  @method destroyLayer
-*/
-destroyLayer() {
-  let leafletLayer = this.get('_leafletObject');
-  if (leafletLayer instanceof L.MarkerClusterGroup) {
-    this.destroyClusterLayer(leafletLayer);
-  }
-},
-
-/**
-  Handles 'flexberry-map:identify' event of leaflet map.
-
-  @method identify
-  @param {Object} e Event object.
-  @param {<a href="http://leafletjs.com/reference.html#polygon">L.Polygon</a>} polygonLayer Polygon layer related to given area.
-  @param {Object[]} layers Objects describing those layers which must be identified.
-  @param {Object[]} results Objects describing identification results.
-  Every result-object has the following structure: { layer: ..., features: [...] },
-  where 'layer' is metadata of layer related to identification result, features is array
-  containing (GeoJSON feature-objects)[http://geojson.org/geojson-spec.html#feature-objects]
-  or a promise returning such array.
-*/
-identify(e) {
-  let primitiveSatisfiesBounds = (primitive, bounds) => {
-    let satisfiesBounds = false;
-
-    if (typeof primitive.forEach === 'function') {
-      primitive.forEach(function (nestedGeometry, index) {
-        if (satisfiesBounds) {
-          return;
-        }
-
-        let nestedPrimitive = this.get(index);
-        satisfiesBounds = primitiveSatisfiesBounds(nestedPrimitive, bounds);
-      });
-    } else {
-      satisfiesBounds = primitive.within(bounds) || primitive.intersects(bounds);
-    }
-
-    return satisfiesBounds;
-  };
-
-  return new Ember.RSVP.Promise((resolve, reject) => {
-    try {
-      let features = Ember.A();
-      let bounds = new Terraformer.Primitive(e.polygonLayer.toGeoJSON());
-      let leafletLayer = this.returnLeafletObject();
-      let mapModel = this.get('mapApi').getFromApi('mapModel');
-      let scale = this.get('mapApi').getFromApi('precisionScale');
-      leafletLayer.eachLayer(function (layer) {
-        let geoLayer = layer.toGeoJSON();
-        let primitive = new Terraformer.Primitive(geoLayer.geometry);
-
-        if (primitiveSatisfiesBounds(primitive, bounds)) {
-          if (geoLayer.geometry.type === 'GeometryCollection') {
-            geoLayer.geometry.geometries.forEach(feat => {
-              let geoObj = { type: 'Feature', geometry: feat };
-              features.pushObject(featureWithAreaIntersect(e.polygonLayer.toGeoJSON(), geoObj, leafletLayer, mapModel, scale));
-            });
-          } else {
-            features.pushObject(featureWithAreaIntersect(e.polygonLayer.toGeoJSON(), geoLayer, leafletLayer, mapModel, scale));
+          if (primitiveSatisfiesBounds(primitive, bounds)) {
+            if (geoLayer.geometry.type === 'GeometryCollection') {
+              geoLayer.geometry.geometries.forEach(feat => {
+                let geoObj = { type: 'Feature', geometry: feat };
+                features.pushObject(featureWithAreaIntersect(e.polygonLayer.toGeoJSON(), geoObj, leafletLayer, mapModel, scale));
+              });
+            } else {
+              features.pushObject(featureWithAreaIntersect(e.polygonLayer.toGeoJSON(), geoLayer, leafletLayer, mapModel, scale));
+            }
           }
+        });
+
+        resolve(features);
+      } catch (e) {
+        reject(e.error || e);
+      }
+    });
+  },
+
+  /**
+    Handles 'flexberry-map:search' event of leaflet map.
+
+    @method search
+    @param {Object} e Event object.
+    @param {<a href="http://leafletjs.com/reference-1.0.0.html#latlng">L.LatLng</a>} e.latlng Center of the search area.
+    @param {Object[]} layer Object describing layer that must be searched.
+    @param {Object} searchOptions Search options related to layer type.
+    @param {Object} results Hash containing search results.
+    @param {Object[]} results.features Array containing (GeoJSON feature-objects)[http://geojson.org/geojson-spec.html#feature-objects]
+    or a promise returning such array.
+  */
+  search(e) {
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      let searchSettingsPath = 'layerModel.settingsAsObject.searchSettings';
+      let leafletLayer = this.returnLeafletObject();
+      let features = Ember.A();
+
+      let searchFields = (e.context ? this.get(`${searchSettingsPath}.contextSearchFields`) : this.get(`${searchSettingsPath}.searchFields`)) || Ember.A();
+
+      // If single search field provided - transform it into array.
+      if (!Ember.isArray(searchFields)) {
+        searchFields = Ember.A([searchFields]);
+      }
+
+      leafletLayer.eachLayer((layer) => {
+        if (features.length < e.searchOptions.maxResultsCount) {
+          let feature = Ember.get(layer, 'feature');
+
+          // if layer satisfies search query
+          let contains = false;
+          searchFields.forEach((field) => {
+            if (feature && (feature.properties[field])) {
+              contains = contains || feature.properties[field].toLowerCase().includes(e.searchOptions.queryString.toLowerCase());
+            }
+          });
+
+          if (contains) {
+            let foundFeature = layer.toGeoJSON();
+            foundFeature.leafletLayer = L.geoJson(foundFeature);
+            features.pushObject(foundFeature);
+          }
+        }
+      });
+      resolve(features);
+    });
+  },
+
+  /**
+    Handles 'flexberry-map:query' event of leaflet map.
+
+    @method _query
+    @param {Object} e Event object.
+    @param {Object} queryFilter Object with query filter paramteres
+    @param {Object[]} results.features Array containing leaflet layers objects
+    or a promise returning such array.
+  */
+  query(layerLinks, e) {
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      let queryFilter = e.queryFilter;
+      let features = Ember.A();
+      let equals = [];
+
+      layerLinks.forEach((link) => {
+        let linkParameters = link.get('parameters');
+
+        if (Ember.isArray(linkParameters) && linkParameters.length > 0) {
+          linkParameters.forEach(linkParam => {
+            let property = linkParam.get('layerField');
+            let propertyValue = queryFilter[linkParam.get('queryKey')];
+
+            equals.push({ 'prop': property, 'value': propertyValue });
+          });
+        }
+      });
+
+      let leafletLayer = this.returnLeafletObject();
+      leafletLayer.eachLayer((layer) => {
+        let feature = Ember.get(layer, 'feature');
+        let meet = true;
+        equals.forEach((equal) => {
+          meet = meet && Ember.isEqual(feature.properties[equal.prop], equal.value);
+        });
+
+        if (meet) {
+          features.pushObject(layer.toGeoJSON());
         }
       });
 
       resolve(features);
-    } catch (e) {
-      reject(e.error || e);
-    }
-  });
-},
+    });
+  },
 
-/**
-  Handles 'flexberry-map:search' event of leaflet map.
+  /**
+    Handles 'flexberry-map:loadLayerFeatures' event of leaflet map.
 
-  @method search
-  @param {Object} e Event object.
-  @param {<a href="http://leafletjs.com/reference-1.0.0.html#latlng">L.LatLng</a>} e.latlng Center of the search area.
-  @param {Object[]} layer Object describing layer that must be searched.
-  @param {Object} searchOptions Search options related to layer type.
-  @param {Object} results Hash containing search results.
-  @param {Object[]} results.features Array containing (GeoJSON feature-objects)[http://geojson.org/geojson-spec.html#feature-objects]
-  or a promise returning such array.
-*/
-search(e) {
-  return new Ember.RSVP.Promise((resolve, reject) => {
-    let searchSettingsPath = 'layerModel.settingsAsObject.searchSettings';
-    let leafletLayer = this.returnLeafletObject();
-    let features = Ember.A();
+    @method loadLayerFeatures
+    @param {Object} e Event object.
+    @returns {Ember.RSVP.Promise} Returns promise.
+  */
+  loadLayerFeatures(e) {
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      resolve(this.returnLeafletObject());
+    });
+  },
 
-    let searchFields = (e.context ? this.get(`${searchSettingsPath}.contextSearchFields`) : this.get(`${searchSettingsPath}.searchFields`)) || Ember.A();
+  /**
+    Handles 'flexberry-map:getLayerFeatures' event of leaflet map.
 
-    // If single search field provided - transform it into array.
-    if (!Ember.isArray(searchFields)) {
-      searchFields = Ember.A([searchFields]);
-    }
-
-    leafletLayer.eachLayer((layer) => {
-      if (features.length < e.searchOptions.maxResultsCount) {
-        let feature = Ember.get(layer, 'feature');
-
-        // if layer satisfies search query
-        let contains = false;
-        searchFields.forEach((field) => {
-          if (feature && (feature.properties[field])) {
-            contains = contains || feature.properties[field].toLowerCase().includes(e.searchOptions.queryString.toLowerCase());
+    @method getLayerFeatures
+    @param {Object} e Event object.
+    @returns {Ember.RSVP.Promise} Returns promise.
+  */
+  getLayerFeatures(e) {
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      let leafletObject = this.returnLeafletObject();
+      let featureIds = e.featureIds;
+      if (Ember.isArray(featureIds) && !Ember.isNone(featureIds)) {
+        let objects = [];
+        featureIds.forEach((id) => {
+          let features = leafletObject._layers;
+          let obj = Object.values(features).find(feature => {
+            return this.get('mapApi').getFromApi('mapModel')._getLayerFeatureId(this.get('layerModel'), feature) === id;
+          });
+          if (!Ember.isNone(obj)) {
+            objects.push(obj);
           }
         });
-
-        if (contains) {
-          let foundFeature = layer.toGeoJSON();
-          foundFeature.leafletLayer = L.geoJson(foundFeature);
-          features.pushObject(foundFeature);
-        }
-      }
-    });
-    resolve(features);
-  });
-},
-
-/**
-  Handles 'flexberry-map:query' event of leaflet map.
-
-  @method _query
-  @param {Object} e Event object.
-  @param {Object} queryFilter Object with query filter paramteres
-  @param {Object[]} results.features Array containing leaflet layers objects
-  or a promise returning such array.
-*/
-query(layerLinks, e) {
-  return new Ember.RSVP.Promise((resolve, reject) => {
-    let queryFilter = e.queryFilter;
-    let features = Ember.A();
-    let equals = [];
-
-    layerLinks.forEach((link) => {
-      let linkParameters = link.get('parameters');
-
-      if (Ember.isArray(linkParameters) && linkParameters.length > 0) {
-        linkParameters.forEach(linkParam => {
-          let property = linkParam.get('layerField');
-          let propertyValue = queryFilter[linkParam.get('queryKey')];
-
-          equals.push({ 'prop': property, 'value': propertyValue });
-        });
-      }
-    });
-
-    let leafletLayer = this.returnLeafletObject();
-    leafletLayer.eachLayer((layer) => {
-      let feature = Ember.get(layer, 'feature');
-      let meet = true;
-      equals.forEach((equal) => {
-        meet = meet && Ember.isEqual(feature.properties[equal.prop], equal.value);
-      });
-
-      if (meet) {
-        features.pushObject(layer.toGeoJSON());
-      }
-    });
-
-    resolve(features);
-  });
-},
-
-/**
-  Handles 'flexberry-map:loadLayerFeatures' event of leaflet map.
-
-  @method loadLayerFeatures
-  @param {Object} e Event object.
-  @returns {Ember.RSVP.Promise} Returns promise.
-*/
-loadLayerFeatures(e) {
-  return new Ember.RSVP.Promise((resolve, reject) => {
-    resolve(this.returnLeafletObject());
-  });
-},
-
-/**
-  Handles 'flexberry-map:getLayerFeatures' event of leaflet map.
-
-  @method getLayerFeatures
-  @param {Object} e Event object.
-  @returns {Ember.RSVP.Promise} Returns promise.
-*/
-getLayerFeatures(e) {
-  return new Ember.RSVP.Promise((resolve, reject) => {
-    let leafletObject = this.returnLeafletObject();
-    let featureIds = e.featureIds;
-    if (Ember.isArray(featureIds) && !Ember.isNone(featureIds)) {
-      let objects = [];
-      featureIds.forEach((id) => {
-        let features = leafletObject._layers;
-        let obj = Object.values(features).find(feature => {
-          return this.get('mapApi').getFromApi('mapModel')._getLayerFeatureId(this.get('layerModel'), feature) === id;
-        });
-        if (!Ember.isNone(obj)) {
-          objects.push(obj);
-        }
-      });
-      resolve(objects);
-    } else {
-      resolve(Object.values(leafletObject._layers));
-    }
-  });
-},
-
-/**
-  Handles 'flexberry-map:getOrLoadLayerFeatures' event of leaflet map.
-
-  @method _getOrLoadLayerFeatures
-  @param {Object} e Event object.
-  @returns {Object[]} results Objects.
-*/
-_getOrLoadLayerFeatures(e) {
-  if (this.get('layerModel.id') !== e.layer) {
-    return;
-  }
-
-  e.results.push({
-    layerModel: this.get('layerModel'),
-    leafletObject: this.returnLeafletObject(),
-    features: e.load ? this.loadLayerFeatures(e) : this.getLayerFeatures(e)
-  });
-},
-
-/**
-  Handles zoomend
-*/
-continueLoad() {
-},
-
-/**
-  Handles 'flexberry-map:continueLoad' event of leaflet map.
-
-  @method search
-  @param {Object} e Event object.
-  @param {Object} layerModel Object describing layer that must be continueLoad.
-  @param {Object} results Hash containing promise.
-*/
-_continueLoad(e) {
-  let shouldContinueLoad = Ember.A(e.layers || []).contains(this.get('layerModel'));
-  if (!shouldContinueLoad) {
-    return;
-  }
-
-  // Call public identify method, if layer should be continueLoad.
-  e.results.push({
-    layerModel: this.get('layerModel'),
-    promise: this.continueLoad(this.returnLeafletObject())
-  });
-},
-
-/*
-  Clear changes. Needs for CancelEdit and Reload
-*/
-clearChanges() {
-},
-
-reload() {
-  this.clearChanges();
-
-  let leafletObject = this.returnLeafletObject();
-  let map = this.get('leafletMap');
-
-  leafletObject.eachLayer((layerShape) => {
-    if (map.hasLayer(layerShape)) {
-      map.removeLayer(layerShape);
-    }
-  });
-  leafletObject.clearLayers();
-
-  this.reloadLabel(leafletObject);
-
-  this.set('loadedBounds', null);
-  let load = this.continueLoad();
-
-  return load && load instanceof Ember.RSVP.Promise ? load : Ember.RSVP.resolve();
-},
-
-/**
-  Adds a listener function to leafletMap.
-
-  @method onLeafletMapEvent
-  @return nothing.
-*/
-onLeafletMapEvent() {
-  let leafletMap = this.get('leafletMap');
-  if (!Ember.isNone(leafletMap)) {
-    leafletMap.on('flexberry-map:getOrLoadLayerFeatures', this._getOrLoadLayerFeatures, this);
-    leafletMap.on('zoomend', this._checkZoomPane, this);
-  }
-},
-
-/**
-  Initializes DOM-related component's properties.
-*/
-didInsertElement() {
-  this._super(...arguments);
-  this.onLeafletMapEvent();
-},
-
-/**
-  Switches pane depending on the zoom.
-
-  @method _checkZoomPane
-  @private
-*/
-_checkZoomPane() {
-  let leafletObject = this.returnLeafletObject();
-  let thisPane = this.get('_pane');
-  let leafletMap = this.get('leafletMap');
-  if (!Ember.isNone(leafletMap) && thisPane && !Ember.isNone(leafletObject)) {
-    let pane = leafletMap.getPane(thisPane);
-    let mapPane = leafletMap._mapPane;
-    if (!Ember.isNone(mapPane) && !Ember.isNone(pane)) {
-
-      let styleRules = this.get('styleRules');
-      let styleZoom = Ember.A();
-      if (!Ember.isNone(styleRules) && styleRules.length > 0) {
-        styleZoom = styleRules.filter(styleRule => {
-          return checkMapZoomStyle(leafletMap, styleRule.rule);
-        });
+        resolve(objects);
       } else {
-        if (checkMapZoom(leafletObject)) {
-          styleZoom.addObject({});
-        }
+        resolve(Object.values(leafletObject._layers));
       }
+    });
+  },
 
-      let existPaneDomElem = Ember.$(mapPane).children(`[class*='${thisPane}']`).length;
-      if (existPaneDomElem > 0 && styleZoom.length === 0) {
-        L.DomUtil.remove(pane);
-      } else if (existPaneDomElem === 0 && styleZoom.length > 0) {
-        mapPane.appendChild(pane);
-      }
-    }
-  }
+  /**
+    Handles 'flexberry-map:getOrLoadLayerFeatures' event of leaflet map.
 
-  this._checkZoomPaneLabel(leafletObject);
-},
-
-/**
-  Deinitializes DOM-related component's properties.
-*/
-willDestroyElement() {
-  this._super(...arguments);
-
-  let leafletMap = this.get('leafletMap');
-  if (!Ember.isNone(leafletMap)) {
-    leafletMap.off('flexberry-map:getOrLoadLayerFeatures', this._getOrLoadLayerFeatures, this);
-
-    if (this.get('typeGeometry') === 'polyline') {
-      leafletMap.off('zoomend', this._updatePositionLabelForLine, this);
+    @method _getOrLoadLayerFeatures
+    @param {Object} e Event object.
+    @returns {Object[]} results Objects.
+  */
+  _getOrLoadLayerFeatures(e) {
+    if (this.get('layerModel.id') !== e.layer) {
+      return;
     }
 
-    if (this.get('showExisting') !== false) {
-      leafletMap.off('moveend', this._showLabelsMovingMap, this);
+    e.results.push({
+      layerModel: this.get('layerModel'),
+      leafletObject: this.returnLeafletObject(),
+      features: e.load ? this.loadLayerFeatures(e) : this.getLayerFeatures(e)
+    });
+  },
+
+  /**
+    Handles zoomend
+  */
+  continueLoad() {
+  },
+
+  /**
+    Handles 'flexberry-map:continueLoad' event of leaflet map.
+
+    @method search
+    @param {Object} e Event object.
+    @param {Object} layerModel Object describing layer that must be continueLoad.
+    @param {Object} results Hash containing promise.
+  */
+  _continueLoad(e) {
+    let shouldContinueLoad = Ember.A(e.layers || []).contains(this.get('layerModel'));
+    if (!shouldContinueLoad) {
+      return;
     }
 
-    let styleRules = this.get('layerModel.settingsAsObject.styleRules');
-    if (styleRules.length > 0) {
-      leafletMap.off('zoomend', this._updateStyleRules, this);
-    }
+    // Call public identify method, if layer should be continueLoad.
+    e.results.push({
+      layerModel: this.get('layerModel'),
+      promise: this.continueLoad(this.returnLeafletObject())
+    });
+  },
 
-    this.willDestroyElementLabel(leafletMap);
-  }
-},
+  /*
+    Clear changes. Needs for CancelEdit and Reload
+  */
+  clearChanges() {
+  },
 
-_createLayer() {
-  this._super(...arguments);
-
-  this.get('_leafletLayerPromise').then((leafletLayer) => {
-    this._checkZoomPane();
-  });
-},
-
-/**
-  Sets leaflet layer's visibility.
-
-  @method _setLayerVisibility
-  @private
-*/
-_setLayerVisibility() {
-  if (this.get('visibility')) {
-    this._addLayerToLeafletContainer();
-    if (this.typeGeometry === 'marker' && !this.clusterize) {
-      this._setLayerStyle();
-    }
+  reload() {
+    this.clearChanges();
 
     let leafletObject = this.returnLeafletObject();
-    this._setLayerVisibilityLabel(leafletObject);
-  } else {
-    this._removeLayerFromLeafletContainer();
-    this._removeLabelsFromLeafletContainer();
-  }
-},
+    let map = this.get('leafletMap');
 
-/**
-  Gets feature properties as plain object.
-  this is necessary to get properties from odata-vector-layer feature
+    leafletObject.eachLayer((layerShape) => {
+      if (map.hasLayer(layerShape)) {
+        map.removeLayer(layerShape);
+      }
+    });
+    leafletObject.clearLayers();
 
-  @method _setLayerVisibility
-  @private
-*/
-_getRegularProperties() {
-  if (!this || !Ember.get(this, 'feature') || !Ember.get(this, 'feature.properties')) {
-    return null;
-  }
+    this.reloadLabel(leafletObject);
 
-  return Ember.get(this, 'feature.properties');
-},
+    this.set('loadedBounds', null);
+    let load = this.continueLoad();
 
-_getGeometry(layer) {
-  let geoJSONLayer = layer.toProjectedGeoJSON(this.get('crs'));
-  let type = layer.toGeoJSON().geometry.type;
-  let forceMulti = this.get('forceMulti') || false;
+    return load && load instanceof Ember.RSVP.Promise ? load : Ember.RSVP.resolve();
+  },
 
-  if (forceMulti && (type === 'Polygon' || type === 'LineString')) {
-    return [geoJSONLayer.geometry.coordinates];
-  } else {
-    return geoJSONLayer.geometry.coordinates;
-  }
-},
+  /**
+    Adds a listener function to leafletMap.
 
-_boundsCrs(leafletObject) {
-  let leafletMap = this.get('leafletMap');
-  let boundsMap = leafletMap.getBounds();
-  if (boundsMap && leafletObject.options && leafletObject.options.crs && leafletObject.options.crs.bounds) {
-    let crsBounds = leafletObject.options.crs.bounds;
-    if (boundsMap._northEast.lat > crsBounds.max.x) {
-      boundsMap._northEast.lat = crsBounds.max.x;
+    @method onLeafletMapEvent
+    @return nothing.
+  */
+  onLeafletMapEvent() {
+    let leafletMap = this.get('leafletMap');
+    if (!Ember.isNone(leafletMap)) {
+      leafletMap.on('flexberry-map:getOrLoadLayerFeatures', this._getOrLoadLayerFeatures, this);
+      leafletMap.on('zoomend', this._checkZoomPane, this);
+    }
+  },
+
+  /**
+    Initializes DOM-related component's properties.
+  */
+  didInsertElement() {
+    this._super(...arguments);
+    this.onLeafletMapEvent();
+  },
+
+  /**
+    Switches pane depending on the zoom.
+
+    @method _checkZoomPane
+    @private
+  */
+  _checkZoomPane() {
+    let leafletObject = this.returnLeafletObject();
+    let thisPane = this.get('_pane');
+    let leafletMap = this.get('leafletMap');
+    if (!Ember.isNone(leafletMap) && thisPane && !Ember.isNone(leafletObject)) {
+      let pane = leafletMap.getPane(thisPane);
+      let mapPane = leafletMap._mapPane;
+      if (!Ember.isNone(mapPane) && !Ember.isNone(pane)) {
+
+        let styleRules = this.get('styleRules');
+        let styleZoom = Ember.A();
+        if (!Ember.isNone(styleRules) && styleRules.length > 0) {
+          styleZoom = styleRules.filter(styleRule => {
+            return checkMapZoomStyle(leafletMap, styleRule.rule);
+          });
+        } else {
+          if (checkMapZoom(leafletObject)) {
+            styleZoom.addObject({});
+          }
+        }
+
+        let existPaneDomElem = Ember.$(mapPane).children(`[class*='${thisPane}']`).length;
+        if (existPaneDomElem > 0 && styleZoom.length === 0) {
+          L.DomUtil.remove(pane);
+        } else if (existPaneDomElem === 0 && styleZoom.length > 0) {
+          mapPane.appendChild(pane);
+        }
+      }
     }
 
-    if (boundsMap._northEast.lng > crsBounds.max.y) {
-      boundsMap._northEast.lng = crsBounds.max.y;
+    this._checkZoomPaneLabel(leafletObject);
+  },
+
+  /**
+    Deinitializes DOM-related component's properties.
+  */
+  willDestroyElement() {
+    this._super(...arguments);
+
+    let leafletMap = this.get('leafletMap');
+    if (!Ember.isNone(leafletMap)) {
+      leafletMap.off('flexberry-map:getOrLoadLayerFeatures', this._getOrLoadLayerFeatures, this);
+
+      if (this.get('typeGeometry') === 'polyline') {
+        leafletMap.off('zoomend', this._updatePositionLabelForLine, this);
+      }
+
+      if (this.get('showExisting') !== false) {
+        leafletMap.off('moveend', this._showLabelsMovingMap, this);
+      }
+
+      let styleRules = this.get('layerModel.settingsAsObject.styleRules');
+      if (styleRules.length > 0) {
+        leafletMap.off('zoomend', this._updateStyleRules, this);
+      }
+
+      this.willDestroyElementLabel(leafletMap);
+    }
+  },
+
+  _createLayer() {
+    this._super(...arguments);
+
+    this.get('_leafletLayerPromise').then((leafletLayer) => {
+      this._checkZoomPane();
+    });
+  },
+
+  /**
+    Sets leaflet layer's visibility.
+
+    @method _setLayerVisibility
+    @private
+  */
+  _setLayerVisibility() {
+    if (this.get('visibility')) {
+      this._addLayerToLeafletContainer();
+      if (this.typeGeometry === 'marker' && !this.clusterize) {
+        this._setLayerStyle();
+      }
+
+      let leafletObject = this.returnLeafletObject();
+      this._setLayerVisibilityLabel(leafletObject);
+    } else {
+      this._removeLayerFromLeafletContainer();
+      this._removeLabelsFromLeafletContainer();
+    }
+  },
+
+  /**
+    Gets feature properties as plain object.
+    this is necessary to get properties from odata-vector-layer feature
+
+    @method _setLayerVisibility
+    @private
+  */
+  _getRegularProperties() {
+    if (!this || !Ember.get(this, 'feature') || !Ember.get(this, 'feature.properties')) {
+      return null;
     }
 
-    if ((boundsMap._southWest.lat < 0 && boundsMap._southWest.lat < crsBounds.min.x) ||
-      (boundsMap._southWest.lat > 0 && boundsMap._southWest.lat > crsBounds.min.x)) {
-      boundsMap._southWest.lat = crsBounds.min.x;
+    return Ember.get(this, 'feature.properties');
+  },
+
+  _getGeometry(layer) {
+    let geoJSONLayer = layer.toProjectedGeoJSON(this.get('crs'));
+    let type = layer.toGeoJSON().geometry.type;
+    let forceMulti = this.get('forceMulti') || false;
+
+    if (forceMulti && (type === 'Polygon' || type === 'LineString')) {
+      return [geoJSONLayer.geometry.coordinates];
+    } else {
+      return geoJSONLayer.geometry.coordinates;
+    }
+  },
+
+  _boundsCrs(leafletObject) {
+    let leafletMap = this.get('leafletMap');
+    let boundsMap = leafletMap.getBounds();
+    if (boundsMap && leafletObject.options && leafletObject.options.crs && leafletObject.options.crs.bounds) {
+      let crsBounds = leafletObject.options.crs.bounds;
+      if (boundsMap._northEast.lat > crsBounds.max.x) {
+        boundsMap._northEast.lat = crsBounds.max.x;
+      }
+
+      if (boundsMap._northEast.lng > crsBounds.max.y) {
+        boundsMap._northEast.lng = crsBounds.max.y;
+      }
+
+      if ((boundsMap._southWest.lat < 0 && boundsMap._southWest.lat < crsBounds.min.x) ||
+        (boundsMap._southWest.lat > 0 && boundsMap._southWest.lat > crsBounds.min.x)) {
+        boundsMap._southWest.lat = crsBounds.min.x;
+      }
+
+      if ((boundsMap._southWest.lng < 0 && boundsMap._southWest.lng < crsBounds.min.y) ||
+        (boundsMap._southWest.lng > 0 && boundsMap._southWest.lng > crsBounds.min.y)) {
+        boundsMap._southWest.lng = crsBounds.min.y;
+      }
     }
 
-    if ((boundsMap._southWest.lng < 0 && boundsMap._southWest.lng < crsBounds.min.y) ||
-      (boundsMap._southWest.lng > 0 && boundsMap._southWest.lng > crsBounds.min.y)) {
-      boundsMap._southWest.lng = crsBounds.min.y;
-    }
+    return boundsMap;
   }
-
-  return boundsMap;
-}
 });

--- a/addon/components/base-vector-layer.js
+++ b/addon/components/base-vector-layer.js
@@ -185,7 +185,7 @@ export default BaseLayer.extend(layerLabel, {
           // It is necessary to clean up the labels with the cluster layer handler
           // that works only for _originalVectorLayer feature addition
           if (this.get('_leafletObject') instanceof L.MarkerClusterGroup) {
-            this.loadClusterLayer({ type:'layeradd', target: this.returnLeafletObject(), layer: {} });
+            this.loadClusterLayer({ type: 'layeradd', target: this.returnLeafletObject(), layer: {} });
           }
         }
 
@@ -281,272 +281,348 @@ export default BaseLayer.extend(layerLabel, {
     }.bind(this));
   },
 
-  /**
-    Creates leaflet vector layer related to layer type.
+/**
+  Creates leaflet vector layer related to layer type.
 
-    @method createVectorLayer
-    @param {Object} options Layer options.
-    @returns <a href="http://leafletjs.com/reference-1.0.1.html#layer">L.Layer</a>|<a href="https://emberjs.com/api/classes/RSVP.Promise.html">Ember.RSVP.Promise</a>
-    Leaflet layer or promise returning such layer.
-  */
-  createVectorLayer(options) {
-    assert('BaseVectorLayer\'s \'createVectorLayer\' should be overridden.');
-  },
+  @method createVectorLayer
+  @param {Object} options Layer options.
+  @returns <a href="http://leafletjs.com/reference-1.0.1.html#layer">L.Layer</a>|<a href="https://emberjs.com/api/classes/RSVP.Promise.html">Ember.RSVP.Promise</a>
+  Leaflet layer or promise returning such layer.
+*/
+createVectorLayer(options) {
+  assert('BaseVectorLayer\'s \'createVectorLayer\' should be overridden.');
+},
 
-  /**
-    Creates read format for the specified leaflet vector layer.
+/**
+  Creates read format for the specified leaflet vector layer.
 
-    @method createReadFormat
-    @param {<a href="http://leafletjs.com/reference-1.0.1.html#layer">L.Layer</a>} Leaflet layer.
-    @returns {Object} Read format.
-  */
-  createReadFormat(vectorLayer) {
-    let crs = this.get('crs');
-    let geometryField = 'geometry';
-    let readFormat = new L.Format.GeoJSON({ crs, geometryField });
+  @method createReadFormat
+  @param {<a href="http://leafletjs.com/reference-1.0.1.html#layer">L.Layer</a>} Leaflet layer.
+  @returns {Object} Read format.
+*/
+createReadFormat(vectorLayer) {
+  let crs = this.get('crs');
+  let geometryField = 'geometry';
+  let readFormat = new L.Format.GeoJSON({ crs, geometryField });
 
-    let layerPropertiesDescription = ``;
-    let layerClass = Ember.getOwner(this).lookup(`layer:${this.get('layerModel.type')}`);
-    let layerProperties = layerClass.getLayerProperties(vectorLayer);
-    for (let i = 0, len = layerProperties.length; i < len; i++) {
-      let layerProperty = layerProperties[i];
-      let layerPropertyValue = layerClass.getLayerPropertyValues(vectorLayer, layerProperty, 1)[0];
+  let layerPropertiesDescription = ``;
+  let layerClass = Ember.getOwner(this).lookup(`layer:${this.get('layerModel.type')}`);
+  let layerProperties = layerClass.getLayerProperties(vectorLayer);
+  for (let i = 0, len = layerProperties.length; i < len; i++) {
+    let layerProperty = layerProperties[i];
+    let layerPropertyValue = layerClass.getLayerPropertyValues(vectorLayer, layerProperty, 1)[0];
 
-      let layerPropertyType = typeof layerPropertyValue;
-      switch (layerPropertyType) {
-        case 'boolean':
-          layerPropertyType = 'boolean';
-          break;
-        case 'number':
-          layerPropertyType = 'decimal';
-          break;
-        case 'object':
-          layerPropertyType = layerPropertyValue instanceof Date ? 'date' : 'string';
-          break;
-        default:
-          layerPropertyType = 'string';
-      }
-
-      layerPropertiesDescription += `<xsd:element maxOccurs="1" minOccurs="0" name="${layerProperty}" nillable="true" type="xsd:${layerPropertyType}"/>`;
+    let layerPropertyType = typeof layerPropertyValue;
+    switch (layerPropertyType) {
+      case 'boolean':
+        layerPropertyType = 'boolean';
+        break;
+      case 'number':
+        layerPropertyType = 'decimal';
+        break;
+      case 'object':
+        layerPropertyType = layerPropertyValue instanceof Date ? 'date' : 'string';
+        break;
+      default:
+        layerPropertyType = 'string';
     }
 
-    let describeFeatureTypeResponse = `` +
-      `<?xml version="1.0" encoding="UTF-8"?>` +
-      `<xsd:schema xmlns:gml="http://www.opengis.net/gml" ` +
-      `xmlns:flexberry="http://flexberry.ru" ` +
-      `xmlns:xsd="http://www.w3.org/2001/XMLSchema" ` +
-      `elementFormDefault="qualified" ` +
-      `targetNamespace="http://flexberry.ru">` +
-      `<xsd:import namespace="http://www.opengis.net/gml" schemaLocation="http://flexberry.ru/schemas/gml/3.1.1/base/gml.xsd"/>` +
-      `<xsd:complexType name="layerType">` +
-      `<xsd:complexContent>` +
-      `<xsd:extension base="gml:AbstractFeatureType">` +
-      `<xsd:sequence>` +
-      `${layerPropertiesDescription}` +
-      `<xsd:element maxOccurs="1" minOccurs="0" name="${geometryField}" nillable="true" type="gml:GeometryPropertyType"/>` +
-      `</xsd:sequence>` +
-      `</xsd:extension>` +
-      `</xsd:complexContent>` +
-      `</xsd:complexType>` +
-      `<xsd:element name="layer" substitutionGroup="gml:_Feature" type="flexberry:layerType"/>` +
-      `</xsd:schema>`;
+    layerPropertiesDescription += `<xsd:element maxOccurs="1" minOccurs="0" name="${layerProperty}" nillable="true" type="xsd:${layerPropertyType}"/>`;
+  }
 
-    let describeFeatureTypeXml = L.XmlUtil.parseXml(describeFeatureTypeResponse);
-    let featureInfo = describeFeatureTypeXml.documentElement;
-    readFormat.setFeatureDescription(featureInfo);
-    readFormat.excludedProperties = [];
+  let describeFeatureTypeResponse = `` +
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<xsd:schema xmlns:gml="http://www.opengis.net/gml" ` +
+    `xmlns:flexberry="http://flexberry.ru" ` +
+    `xmlns:xsd="http://www.w3.org/2001/XMLSchema" ` +
+    `elementFormDefault="qualified" ` +
+    `targetNamespace="http://flexberry.ru">` +
+    `<xsd:import namespace="http://www.opengis.net/gml" schemaLocation="http://flexberry.ru/schemas/gml/3.1.1/base/gml.xsd"/>` +
+    `<xsd:complexType name="layerType">` +
+    `<xsd:complexContent>` +
+    `<xsd:extension base="gml:AbstractFeatureType">` +
+    `<xsd:sequence>` +
+    `${layerPropertiesDescription}` +
+    `<xsd:element maxOccurs="1" minOccurs="0" name="${geometryField}" nillable="true" type="gml:GeometryPropertyType"/>` +
+    `</xsd:sequence>` +
+    `</xsd:extension>` +
+    `</xsd:complexContent>` +
+    `</xsd:complexType>` +
+    `<xsd:element name="layer" substitutionGroup="gml:_Feature" type="flexberry:layerType"/>` +
+    `</xsd:schema>`;
 
-    return readFormat;
-  },
+  let describeFeatureTypeXml = L.XmlUtil.parseXml(describeFeatureTypeResponse);
+  let featureInfo = describeFeatureTypeXml.documentElement;
+  readFormat.setFeatureDescription(featureInfo);
+  readFormat.excludedProperties = [];
 
-  /**
-    Clusterizes created vector layer if 'clusterize' option is enabled.
+  return readFormat;
+},
 
-    @method createClusterLayer
-    @param {<a href="http://leafletjs.com/reference-1.0.1.html#layer">L.Layer</a>} vectorLayer Vector layer which must be clusterized.
-    @return {<a href="https://github.com/Leaflet/Leaflet.markercluster/blob/master/src/MarkerClusterGroup.js">L.MarkerClusterGroup</a>} Clusterized vector layer.
-  */
-  createClusterLayer(vectorLayer) {
-    let clusterLayer = L.markerClusterGroup(this.get('clusterOptions'));
+/**
+  Clusterizes created vector layer if 'clusterize' option is enabled.
 
-    // Original vector layer is necessary for 'flexberry-layers-attributes-panel' component and identification map tool
-    clusterLayer._originalVectorLayer = vectorLayer;
+  @method createClusterLayer
+  @param {<a href="http://leafletjs.com/reference-1.0.1.html#layer">L.Layer</a>} vectorLayer Vector layer which must be clusterized.
+  @return {<a href="https://github.com/Leaflet/Leaflet.markercluster/blob/master/src/MarkerClusterGroup.js">L.MarkerClusterGroup</a>} Clusterized vector layer.
+*/
+createClusterLayer(vectorLayer) {
+  let clusterLayer = L.markerClusterGroup(this.get('clusterOptions'));
 
-    // Features loading of original vectorLayer does not trigger parent's clusterLayer.addLayer(), link explicitly
-    clusterLayer._originalVectorLayer.on('layeradd', this.loadClusterLayer, this);
-    clusterLayer._originalVectorLayer.on('layerremove', this.loadClusterLayer, this);
+  // Original vector layer is necessary for 'flexberry-layers-attributes-panel' component and identification map tool
+  clusterLayer._originalVectorLayer = vectorLayer;
 
-    // Apply display settings for clustered features.
-    clusterLayer._featureGroup.on('layeradd', this.updateClusterLayer, this);
-    clusterLayer._featureGroup.on('layerremove', this.updateClusterLayer, this);
+  // Features loading of original vectorLayer does not trigger parent's clusterLayer.addLayer(), link explicitly
+  clusterLayer._originalVectorLayer.on('layeradd', this.loadClusterLayer, this);
+  clusterLayer._originalVectorLayer.on('layerremove', this.loadClusterLayer, this);
 
-    clusterLayer.addLayer(vectorLayer);
+  // Apply display settings for clustered features.
+  clusterLayer._featureGroup.on('layeradd', this.updateClusterLayer, this);
+  clusterLayer._featureGroup.on('layerremove', this.updateClusterLayer, this);
 
-    return clusterLayer;
-  },
-  /**
-    Apply display settings for clustered objects. Updating the visibility of the feature labels, opacity.
+  clusterLayer.addLayer(vectorLayer);
 
-    @method updateClusterLayer
-    @param {Object} e action context.
-  */
-  updateClusterLayer(e) {
-    this._setLayerOpacity();
+  return clusterLayer;
+},
+/**
+  Apply display settings for clustered objects. Updating the visibility of the feature labels, opacity.
 
-    if (!e || !e.layer || !e.type) {
-      return;
-    }
+  @method updateClusterLayer
+  @param {Object} e action context.
+*/
+updateClusterLayer(e) {
+  this._setLayerOpacity();
 
-    if (e.layer instanceof L.MarkerCluster) {
-      return;
-    }
+  if (!e || !e.layer || !e.type) {
+    return;
+  }
 
-    let leafletMap = this.get('leafletMap');
-    let layerLabel = e.layer._label;
+  if (e.layer instanceof L.MarkerCluster) {
+    return;
+  }
 
+  let leafletMap = this.get('leafletMap');
+  let layerLabel = e.layer._label;
+
+  if (e.type === 'layeradd') {
+    this._setLayerStyle();
+  }
+
+  if (layerLabel) {
     if (e.type === 'layeradd') {
-      this._setLayerStyle();
+      layerLabel.forEach(label => {
+        if (!leafletMap.hasLayer(label)) {
+          leafletMap.addLayer(label);
+        }
+      });
+    } else {
+      layerLabel.forEach(label => {
+        if (leafletMap.hasLayer(label)) {
+          leafletMap.removeLayer(label);
+        }
+      });
     }
+  }
+},
 
-    if (layerLabel) {
-      if (e.type === 'layeradd') {
-        layerLabel.forEach(label => {
-          if (!leafletMap.hasLayer(label)) {
-            leafletMap.addLayer(label);
-          }
-        });
-      } else {
-        layerLabel.forEach(label => {
-          if (leafletMap.hasLayer(label)) {
-            leafletMap.removeLayer(label);
-          }
-        });
-      }
-    }
-  },
+/**
+  Synchronizes ClusterLayer._originalVectorLayer._layers with ClusterLayer layers.
+  This is required when continueLoading option.
 
-  /**
-    Synchronizes ClusterLayer._originalVectorLayer._layers with ClusterLayer layers.
-    This is required when continueLoading option.
+  @method loadClusterLayer
+  @param {Object} e action context.
+*/
+loadClusterLayer(e) {
+  if (!e || !e.layer) {
+    return;
+  }
 
-    @method loadClusterLayer
-    @param {Object} e action context.
-  */
-  loadClusterLayer(e) {
-    if (!e || !e.layer) {
-      return;
-    }
+  if (e.type === 'layeradd') {
+    Ember.run.once(this, 'addClusterLayer', e);
+    return;
+  }
 
-    if (e.type === 'layeradd') {
-      Ember.run.once(this, 'addClusterLayer', e);
-      return;
-    }
+  let clusterLayer = this.get('_leafletObject');
+  if (!(clusterLayer instanceof L.MarkerClusterGroup)) {
+    return;
+  }
 
-    let clusterLayer = this.get('_leafletObject');
-    if (!(clusterLayer instanceof L.MarkerClusterGroup)) {
-      return;
-    }
+  clusterLayer.removeLayer(e.layer);
+},
 
-    clusterLayer.removeLayer(e.layer);
-  },
+/**
+  Adds ClusterLayer layers.
 
-  /**
-    Adds ClusterLayer layers.
+  @method addClusterLayer
+  @param {Object} e action context.
+*/
+addClusterLayer(e) {
+  if (!e || !e.target) {
+    console.error('Unable to update clusterLayer');
+    return;
+  }
 
-    @method addClusterLayer
-    @param {Object} e action context.
-  */
-  addClusterLayer(e) {
-    if (!e || !e.target) {
-      console.error('Unable to update clusterLayer');
-      return;
-    }
+  let clusterLayer = this.get('_leafletObject');
+  let leafletMap = this.get('leafletMap');
+  if (!(clusterLayer instanceof L.MarkerClusterGroup)) {
+    return;
+  }
 
-    let clusterLayer = this.get('_leafletObject');
-    let leafletMap = this.get('leafletMap');
-    if (!(clusterLayer instanceof L.MarkerClusterGroup)) {
-      return;
-    }
+  let updatedOriginalVectorLayer = e.target;
+  clusterLayer.addLayer(updatedOriginalVectorLayer);
 
-    let updatedOriginalVectorLayer = e.target;
-    clusterLayer.addLayer(updatedOriginalVectorLayer);
+  // L.MarkerClusterGroup includes both child L.MarkerCluster and L.Marker in _featureGroup after originalVectorLayer addition
+  let clusterMarkers = clusterLayer._featureGroup.getLayers().filter(layer => layer instanceof L.MarkerCluster);
 
-    // L.MarkerClusterGroup includes both child L.MarkerCluster and L.Marker in _featureGroup after originalVectorLayer addition
-    let clusterMarkers = clusterLayer._featureGroup.getLayers().filter(layer => layer instanceof L.MarkerCluster);
-
-    clusterMarkers.forEach(clusterMarker => {
-      // For L.MarkerCluster there is an option to get clustered markers
-      clusterMarker.getAllChildMarkers()
-        .filter(markerLayer => {
-          return markerLayer._label.some(label => {
-            return leafletMap.hasLayer(label);
-          });
-        })
-        .map(markerLayerWithLabel => {
-          markerLayerWithLabel._label.forEach(label => {
-            leafletMap.removeLayer(label);
-          });
-        });
-    });
-
-    this._setLayerState(); // Accept layer style options for new loaded features
-  },
-
-  /**
-    Destroys clusterized leaflet layer related to layer type.
-
-    @method destroyLayer
-  */
-  destroyClusterLayer(clusterLayer) {
-    clusterLayer._featureGroup.off('layeradd', this.updateClusterLayer, this);
-    clusterLayer._featureGroup.off('layerremove', this.updateClusterLayer, this);
-    clusterLayer._originalVectorLayer.off('layeradd', this.loadClusterLayer, this);
-    clusterLayer._originalVectorLayer.off('layerremove', this.loadClusterLayer, this);
-  },
-
-  /*
-    Get the field to search for objects
-    @method getPkField
-    @param {Object} layer.
-    @return {String} Field name.
-  */
-  getPkField(layer) {
-    const getPkField = this.get('mapApi').getFromApi('getPkField');
-    if (typeof getPkField === 'function') {
-      return getPkField(layer);
-    }
-
-    let field = Ember.get(layer, 'settingsAsObject.pkField');
-    return Ember.isNone(field) ? 'primarykey' : field;
-  },
-
-  /**
-    Show all layer objects.
-    @method showAllLayerObjects
-    @return {Promise}
-  */
-  showAllLayerObjects() {
-    return new Ember.RSVP.Promise((resolve, reject) => {
-      let leafletObject = this.returnLeafletObject();
-      let map = this.get('leafletMap');
-      let layer = this.get('layerModel');
-
-      let continueLoading = leafletObject.options.continueLoading;
-      if (!continueLoading) {
-        if (!Ember.isNone(leafletObject)) {
-          leafletObject.eachLayer((layerShape) => {
-            if (map.hasLayer(layerShape)) {
-              map.removeLayer(layerShape);
-            }
-          });
-          if (!leafletObject.options.showExisting) {
-            leafletObject.clearLayers();
-          }
+  clusterMarkers.forEach(clusterMarker => {
+    // For L.MarkerCluster there is an option to get clustered markers
+    clusterMarker.getAllChildMarkers()
+      .filter(markerLayer => {
+        if (Ember.isNone(markerLayer._label) || !Ember.isArray(markerLayer._label)) {
+          return false;
         }
 
+        return markerLayer._label.some(label => {
+          return leafletMap.hasLayer(label);
+        });
+      })
+      .map(markerLayerWithLabel => {
+        markerLayerWithLabel._label.forEach(label => {
+          leafletMap.removeLayer(label);
+        });
+      });
+  });
+
+  this._setLayerState(); // Accept layer style options for new loaded features
+},
+
+/**
+  Destroys clusterized leaflet layer related to layer type.
+
+  @method destroyLayer
+*/
+destroyClusterLayer(clusterLayer) {
+  clusterLayer._featureGroup.off('layeradd', this.updateClusterLayer, this);
+  clusterLayer._featureGroup.off('layerremove', this.updateClusterLayer, this);
+  clusterLayer._originalVectorLayer.off('layeradd', this.loadClusterLayer, this);
+  clusterLayer._originalVectorLayer.off('layerremove', this.loadClusterLayer, this);
+},
+
+/*
+  Get the field to search for objects
+  @method getPkField
+  @param {Object} layer.
+  @return {String} Field name.
+*/
+getPkField(layer) {
+  const getPkField = this.get('mapApi').getFromApi('getPkField');
+  if (typeof getPkField === 'function') {
+    return getPkField(layer);
+  }
+
+  let field = Ember.get(layer, 'settingsAsObject.pkField');
+  return Ember.isNone(field) ? 'primarykey' : field;
+},
+
+/**
+  Show all layer objects.
+  @method showAllLayerObjects
+  @return {Promise}
+*/
+showAllLayerObjects() {
+  return new Ember.RSVP.Promise((resolve, reject) => {
+    let leafletObject = this.returnLeafletObject();
+    let map = this.get('leafletMap');
+    let layer = this.get('layerModel');
+
+    let continueLoading = leafletObject.options.continueLoading;
+    if (!continueLoading) {
+      if (!Ember.isNone(leafletObject)) {
+        leafletObject.eachLayer((layerShape) => {
+          if (map.hasLayer(layerShape)) {
+            map.removeLayer(layerShape);
+          }
+        });
+        if (!leafletObject.options.showExisting) {
+          leafletObject.clearLayers();
+        }
+      }
+
+      leafletObject.promiseLoadLayer = new Ember.RSVP.Promise((resolve) => {
+        let e = {
+          featureIds: null
+        };
+
+        leafletObject.loadLayerFeatures(e).then(() => {
+          resolve('Features loaded');
+        });
+      });
+    } else {
+      leafletObject.showLayerObjects = true;
+      leafletObject.statusLoadLayer = true;
+
+      this.continueLoad(leafletObject);
+      if (Ember.isNone(leafletObject.promiseLoadLayer) || !(leafletObject.promiseLoadLayer instanceof Ember.RSVP.Promise)) {
+        leafletObject.promiseLoadLayer = Ember.RSVP.resolve();
+      }
+    }
+
+    leafletObject.promiseLoadLayer.then(() => {
+      leafletObject.statusLoadLayer = false;
+      leafletObject.promiseLoadLayer = null;
+      leafletObject.eachLayer(function (layerShape) {
+        if (!map.hasLayer(layerShape)) {
+          map.addLayer(layerShape);
+        }
+      });
+
+      this.showAllLayerObjectsLabel(leafletObject, layer);
+
+      resolve('success');
+    });
+  });
+},
+
+/**
+  Hide all layer objects.
+  @method hideAllLayerObjects
+  @return nothing
+*/
+hideAllLayerObjects() {
+  let leafletObject = this.returnLeafletObject();
+  let map = this.get('leafletMap');
+  let layer = this.get('layerModel');
+
+  leafletObject.showLayerObjects = false;
+
+  leafletObject.eachLayer(function (layerShape) {
+    if (map.hasLayer(layerShape)) {
+      map.removeLayer(layerShape);
+    }
+  });
+
+  this.hideAllLayerObjectsLabel(leafletObject, layer);
+},
+
+/**
+  Determine the visibility of the specified objects by id for the layer.
+  @method _setVisibilityObjects
+  @param {string[]} objectIds Array of objects IDs.
+  @param {boolean} [visibility=false] visibility Object Visibility.
+  @return {Ember.RSVP.Promise}
+*/
+_setVisibilityObjects(objectIds, visibility = false) {
+  return new Ember.RSVP.Promise((resolve, reject) => {
+    let leafletObject = this.returnLeafletObject();
+    let map = this.get('leafletMap');
+    let layer = this.get('layerModel');
+
+    if (visibility) {
+      let continueLoading = leafletObject.options.continueLoading;
+      if (!continueLoading) {
         leafletObject.promiseLoadLayer = new Ember.RSVP.Promise((resolve) => {
           let e = {
-            featureIds: null
+            featureIds: objectIds
           };
 
           leafletObject.loadLayerFeatures(e).then(() => {
@@ -554,795 +630,723 @@ export default BaseLayer.extend(layerLabel, {
           });
         });
       } else {
-        leafletObject.showLayerObjects = true;
-        leafletObject.statusLoadLayer = true;
-
-        this.continueLoad(leafletObject);
-        if (Ember.isNone(leafletObject.promiseLoadLayer) || !(leafletObject.promiseLoadLayer instanceof Ember.RSVP.Promise)) {
-          leafletObject.promiseLoadLayer = Ember.RSVP.resolve();
-        }
+        reject('Not working to layer with continueLoading');
       }
+    } else {
+      leafletObject.promiseLoadLayer = Ember.RSVP.resolve();
+    }
 
-      leafletObject.promiseLoadLayer.then(() => {
-        leafletObject.statusLoadLayer = false;
-        leafletObject.promiseLoadLayer = null;
-        leafletObject.eachLayer(function (layerShape) {
-          if (!map.hasLayer(layerShape)) {
-            map.addLayer(layerShape);
-          }
+    leafletObject.promiseLoadLayer.then(() => {
+      leafletObject.statusLoadLayer = false;
+      leafletObject.promiseLoadLayer = null;
+      objectIds.forEach(objectId => {
+        let objects = Object.values(leafletObject._layers).filter(shape => {
+          return this.get('mapApi').getFromApi('mapModel')._getLayerFeatureId(layer, shape) === objectId;
         });
-
-        this.showAllLayerObjectsLabel(leafletObject, layer);
-
-        resolve('success');
-      });
-    });
-  },
-
-  /**
-    Hide all layer objects.
-    @method hideAllLayerObjects
-    @return nothing
-  */
-  hideAllLayerObjects() {
-    let leafletObject = this.returnLeafletObject();
-    let map = this.get('leafletMap');
-    let layer = this.get('layerModel');
-
-    leafletObject.showLayerObjects = false;
-
-    leafletObject.eachLayer(function (layerShape) {
-      if (map.hasLayer(layerShape)) {
-        map.removeLayer(layerShape);
-      }
-    });
-
-    this.hideAllLayerObjectsLabel(leafletObject, layer);
-  },
-
-  /**
-    Determine the visibility of the specified objects by id for the layer.
-    @method _setVisibilityObjects
-    @param {string[]} objectIds Array of objects IDs.
-    @param {boolean} [visibility=false] visibility Object Visibility.
-    @return {Ember.RSVP.Promise}
-  */
-  _setVisibilityObjects(objectIds, visibility = false) {
-    return new Ember.RSVP.Promise((resolve, reject) => {
-      let leafletObject = this.returnLeafletObject();
-      let map = this.get('leafletMap');
-      let layer = this.get('layerModel');
-
-      if (visibility) {
-        let continueLoading = leafletObject.options.continueLoading;
-        if (!continueLoading) {
-          leafletObject.promiseLoadLayer = new Ember.RSVP.Promise((resolve) => {
-            let e = {
-              featureIds: objectIds
-            };
-
-            leafletObject.loadLayerFeatures(e).then(() => {
-              resolve('Features loaded');
-            });
+        if (objects.length > 0) {
+          objects.forEach(obj => {
+            if (visibility) {
+              map.addLayer(obj);
+            } else {
+              map.removeLayer(obj);
+            }
           });
+        }
+      });
+
+      this._setVisibilityObjectsLabel(leafletObject, layer, objectIds, visibility);
+
+      resolve('success');
+    });
+  });
+},
+
+/**
+  Get nearest object.
+  Gets all leaflet layer objects and processes them _calcNearestObject().
+
+  @method getNearObject
+  @param {Object} e Event object..
+  @param {Object} featureLayer Leaflet layer object.
+  @param {Number} featureId Leaflet layer object id.
+  @param {Number} layerObjectId Leaflet layer id.
+  @return {Ember.RSVP.Promise} Returns object with distance, layer model and nearest leaflet layer object.
+*/
+getNearObject(e) {
+  return new Ember.RSVP.Promise((resolve, reject) => {
+    let features = {
+      featureIds: null
+    };
+    this.getLayerFeatures(features)
+      .then((featuresLayer) => {
+        if (Ember.isArray(featuresLayer) && featuresLayer.length > 0) {
+          resolve(this._calcNearestObject(featuresLayer, e));
         } else {
-          reject('Not working to layer with continueLoading');
+          resolve('Nearest object not found');
         }
-      } else {
-        leafletObject.promiseLoadLayer = Ember.RSVP.resolve();
-      }
-
-      leafletObject.promiseLoadLayer.then(() => {
-        leafletObject.statusLoadLayer = false;
-        leafletObject.promiseLoadLayer = null;
-        objectIds.forEach(objectId => {
-          let objects = Object.values(leafletObject._layers).filter(shape => {
-            return this.get('mapApi').getFromApi('mapModel')._getLayerFeatureId(layer, shape) === objectId;
-          });
-          if (objects.length > 0) {
-            objects.forEach(obj => {
-              if (visibility) {
-                map.addLayer(obj);
-              } else {
-                map.removeLayer(obj);
-              }
-            });
-          }
-        });
-
-        this._setVisibilityObjectsLabel(leafletObject, layer, objectIds, visibility);
-
-        resolve('success');
+      })
+      .catch((error) => {
+        reject(error);
       });
-    });
-  },
+  });
+},
 
-  /**
-    Get nearest object.
-    Gets all leaflet layer objects and processes them _calcNearestObject().
+/**
+  Calculates nearest object.
+  Iterates all objects and calculates min distance. If it searches for nearest object in same layer, it is excluded e.featureLayer.
 
-    @method getNearObject
-    @param {Object} e Event object..
-    @param {Object} featureLayer Leaflet layer object.
-    @param {Number} featureId Leaflet layer object id.
-    @param {Number} layerObjectId Leaflet layer id.
-    @return {Ember.RSVP.Promise} Returns object with distance, layer model and nearest leaflet layer object.
-  */
-  getNearObject(e) {
-    return new Ember.RSVP.Promise((resolve, reject) => {
-      let features = {
-        featureIds: null
+  @method getNearObject
+  @param {Array} featuresLayer Leaflet layer objects.
+  @param {Object} e Event object..
+  @param {Object} featureLayer Leaflet layer object.
+  @param {Number} featureId Leaflet layer object id.
+  @param {Number} layerObjectId Leaflet layer id.
+  @return {Ember.RSVP.Promise} Returns object with distance, layer model and nearest leaflet layer object.
+*/
+_calcNearestObject(featuresLayer, e) {
+  let result = null;
+  let mapApi = this.get('mapApi').getFromApi('mapModel');
+  let layerModel = this.get('layerModel');
+  let layerId = layerModel.get('id');
+  featuresLayer.forEach(obj => {
+    let leafletLayer = Ember.isNone(obj.leafletLayer) ? obj : obj.leafletLayer;
+    const id = mapApi._getLayerFeatureId(layerModel, leafletLayer);
+    if (layerId === e.layerObjectId && e.featureId === id) {
+      return;
+    }
+
+    const distance = mapApi._getDistanceBetweenObjects(e.featureLayer, leafletLayer);
+    if (Ember.isNone(result) || distance < result.distance) {
+      result = {
+        distance: distance,
+        layer: layerModel,
+        object: leafletLayer,
       };
-      this.getLayerFeatures(features)
-        .then((featuresLayer) => {
-          if (Ember.isArray(featuresLayer) && featuresLayer.length > 0) {
-            resolve(this._calcNearestObject(featuresLayer, e));
-          } else {
-            resolve('Nearest object not found');
-          }
-        })
-        .catch((error) => {
-          reject(error);
-        });
-    });
-  },
+    }
+  });
+  return result;
+},
 
-  /**
-    Calculates nearest object.
-    Iterates all objects and calculates min distance. If it searches for nearest object in same layer, it is excluded e.featureLayer.
+/**
+  Creates leaflet layer related to layer type.
 
-    @method getNearObject
-    @param {Array} featuresLayer Leaflet layer objects.
-    @param {Object} e Event object..
-    @param {Object} featureLayer Leaflet layer object.
-    @param {Number} featureId Leaflet layer object id.
-    @param {Number} layerObjectId Leaflet layer id.
-    @return {Ember.RSVP.Promise} Returns object with distance, layer model and nearest leaflet layer object.
-  */
-  _calcNearestObject(featuresLayer, e) {
-    let result = null;
-    let mapApi = this.get('mapApi').getFromApi('mapModel');
-    let layerModel = this.get('layerModel');
-    let layerId = layerModel.get('id');
-    featuresLayer.forEach(obj => {
-      let leafletLayer = Ember.isNone(obj.leafletLayer) ? obj : obj.leafletLayer;
-      const id = mapApi._getLayerFeatureId(layerModel, leafletLayer);
-      if (layerId === e.layerObjectId && e.featureId === id) {
-        return;
+  @method createLayer
+  @return {<a href="http://leafletjs.com/reference-1.0.1.html#layer">L.Layer</a>|<a href="https://emberjs.com/api/classes/RSVP.Promise.html">Ember.RSVP.Promise</a>}
+  Leaflet layer or promise returning such layer.
+*/
+createLayer() {
+  return new Ember.RSVP.Promise((resolve, reject) => {
+    Ember.RSVP.hash({
+      vectorLayer: this.createVectorLayer()
+    }).then(({ vectorLayer }) => {
+      // Read format contains 'DescribeFeatureType' metadata and is necessary for 'flexberry-layers-attributes-panel' component.
+      let readFormat = vectorLayer.readFormat;
+      if (Ember.isNone(readFormat)) {
+        // For combine layer
+        if (!Ember.isNone(this.dynamicProperties) && !Ember.isNone(this.dynamicProperties.type)) {
+          vectorLayer.type = this.dynamicProperties.type;
+        }
+
+        vectorLayer.readFormat = this.createReadFormat(vectorLayer);
       }
 
-      const distance = mapApi._getDistanceBetweenObjects(e.featureLayer, leafletLayer);
-      if (Ember.isNone(result) || distance < result.distance) {
-        result = {
-          distance: distance,
-          layer: layerModel,
-          object: leafletLayer,
-        };
+      vectorLayer.minZoom = this.get('minZoom');
+      vectorLayer.maxZoom = this.get('maxZoom');
+
+      vectorLayer.getContainer = this.get('_getContainer').bind(this);
+      vectorLayer.getPkField = this.get('getPkField').bind(this);
+      vectorLayer.showAllLayerObjects = this.get('showAllLayerObjects').bind(this);
+      vectorLayer.hideAllLayerObjects = this.get('hideAllLayerObjects').bind(this);
+      vectorLayer._setVisibilityObjects = this.get('_setVisibilityObjects').bind(this);
+
+      // change style by change zoom
+      let styleRules = this.get('layerModel.settingsAsObject.styleRules');
+      if (styleRules && styleRules.length > 0) {
+        this.set('styleRules', styleRules);
+        this.set('layerModel.styleRules', styleRules);
+        this._updateStyleRules();
+        this.get('leafletMap').on('zoomend', this._updateStyleRules, this);
       }
-    });
-    return result;
-  },
 
-  /**
-    Creates leaflet layer related to layer type.
+      // load images for style
+      let imagePromises = Ember.A();
+      let styleSettings = this.get('layerModel.settingsAsObject.styleSettings');
+      if (!Ember.isNone(styleRules) && styleRules.length > 0) {
+        this._imageFromStyleRules(imagePromises);
+      } else if (!Ember.isNone(styleSettings)) {
+        this._imageFromStyleSettings(imagePromises, styleSettings);
+      }
 
-    @method createLayer
-    @return {<a href="http://leafletjs.com/reference-1.0.1.html#layer">L.Layer</a>|<a href="https://emberjs.com/api/classes/RSVP.Promise.html">Ember.RSVP.Promise</a>}
-    Leaflet layer or promise returning such layer.
-  */
-  createLayer() {
-    return new Ember.RSVP.Promise((resolve, reject) => {
-      Ember.RSVP.hash({
-        vectorLayer: this.createVectorLayer()
-      }).then(({ vectorLayer }) => {
-        // Read format contains 'DescribeFeatureType' metadata and is necessary for 'flexberry-layers-attributes-panel' component.
-        let readFormat = vectorLayer.readFormat;
-        if (Ember.isNone(readFormat)) {
-          // For combine layer
-          if (!Ember.isNone(this.dynamicProperties) && !Ember.isNone(this.dynamicProperties.type)) {
-            vectorLayer.type = this.dynamicProperties.type;
-          }
+      if (Ember.isNone(vectorLayer.loadLayerFeatures)) {
+        Ember.set(vectorLayer, 'loadLayerFeatures', this.loadLayerFeatures.bind(this));
+      }
 
-          vectorLayer.readFormat = this.createReadFormat(vectorLayer);
-        }
+      let resultLayer = vectorLayer;
+      if (this.get('clusterize')) {
+        let clusterLayer = this.createClusterLayer(vectorLayer);
+        resultLayer = clusterLayer;
+      }
 
-        vectorLayer.minZoom = this.get('minZoom');
-        vectorLayer.maxZoom = this.get('maxZoom');
-
-        vectorLayer.getContainer = this.get('_getContainer').bind(this);
-        vectorLayer.getPkField = this.get('getPkField').bind(this);
-        vectorLayer.showAllLayerObjects = this.get('showAllLayerObjects').bind(this);
-        vectorLayer.hideAllLayerObjects = this.get('hideAllLayerObjects').bind(this);
-        vectorLayer._setVisibilityObjects = this.get('_setVisibilityObjects').bind(this);
-
-        // change style by change zoom
-        let styleRules = this.get('layerModel.settingsAsObject.styleRules');
-        if (styleRules && styleRules.length > 0) {
-          this.set('styleRules', styleRules);
-          this.set('layerModel.styleRules', styleRules);
-          this._updateStyleRules();
-          this.get('leafletMap').on('zoomend', this._updateStyleRules, this);
-        }
-
-        // load images for style
-        let imagePromises = Ember.A();
-        let styleSettings = this.get('layerModel.settingsAsObject.styleSettings');
-        if (!Ember.isNone(styleRules) && styleRules.length > 0) {
-          this._imageFromStyleRules(imagePromises);
-        } else if (!Ember.isNone(styleSettings)) {
-          this._imageFromStyleSettings(imagePromises, styleSettings);
-        }
-
-        if (Ember.isNone(vectorLayer.loadLayerFeatures)) {
-          Ember.set(vectorLayer, 'loadLayerFeatures', this.loadLayerFeatures.bind(this));
-        }
-
-        let resultLayer = vectorLayer;
-        if (this.get('clusterize')) {
-          let clusterLayer = this.createClusterLayer(vectorLayer);
-          resultLayer = clusterLayer;
-        }
-
-        if (imagePromises.length > 0) {
-          Ember.RSVP.allSettled(imagePromises).then((styles) => {
-            styles.forEach(style => {
-              for (let property in style.value) {
-                if (!Ember.isNone(style.value[property].tagName)) {
-                  styleSettings.style.path[property].imagePattern = style.value[property];
-                } else {
-                  for (let propertyInner in style.value[property]) {
-                    styleRules[property].styleSettings.style.path[propertyInner].imagePattern = style.value[property][propertyInner];
-                  }
+      if (imagePromises.length > 0) {
+        Ember.RSVP.allSettled(imagePromises).then((styles) => {
+          styles.forEach(style => {
+            for (let property in style.value) {
+              if (!Ember.isNone(style.value[property].tagName)) {
+                styleSettings.style.path[property].imagePattern = style.value[property];
+              } else {
+                for (let propertyInner in style.value[property]) {
+                  styleRules[property].styleSettings.style.path[propertyInner].imagePattern = style.value[property][propertyInner];
                 }
               }
-            });
-            resolve(resultLayer);
+            }
           });
-        } else {
           resolve(resultLayer);
-        }
-      }).catch((e) => {
-        reject(e);
-      });
-    });
-  },
-
-  /**
-    Add in array promise which load pattern from styleSettings.
-
-    @method _imageFromStyleSettings
-  */
-  _imageFromStyleSettings(imagePromises, styleSettings, index) {
-    if (styleSettings.style.path) {
-      if (Ember.isArray(styleSettings.style.path)) {
-        styleSettings.style.path.forEach((style, i) => {
-          if (style.fillStyle === 'pattern') {
-            imagePromises.addObject(this._setPattern(style, i, index));
-          }
-        });
-      } else if (styleSettings.style.path.fillStyle === 'pattern') {
-        imagePromises.addObject(this._setPattern(styleSettings.style.path, 0, index));
-      }
-    }
-  },
-
-  /**
-    For each styleRules load pattern.
-
-    @method _imageFromStyleRules
-  */
-  _imageFromStyleRules(imagePromises) {
-    let styleRules = this.get('styleRules');
-    if (Ember.isNone(styleRules)) {
-      return;
-    }
-
-    styleRules.forEach((styleRule, i) => {
-      this._imageFromStyleSettings(imagePromises, styleRule.styleSettings, i);
-    });
-  },
-
-  /**
-    Change styleSettings depending on the zoom.
-
-    @method _updateStyleRules
-  */
-  _updateStyleRules() {
-    let styleRules = this.get('styleRules');
-    if (Ember.isNone(styleRules)) {
-      return;
-    }
-
-    let leafletMap = this.get('leafletMap');
-    styleRules.forEach(styleRule => {
-      let rule = styleRule.rule;
-      let caption = `${this.get('i18n').t('components.base-vector-layer.zoomFrom').string} ${rule.minZoom}
-        ${this.get('i18n').t('components.base-vector-layer.zoomTo').string} ${rule.maxZoom}`;
-      Ember.set(rule, 'caption', caption);
-      if (checkMapZoomStyle(leafletMap, styleRule.rule) && this.get('styleSettings') !== styleRule.styleSettings) {
-        this.set('styleSettings', styleRule.styleSettings);
-      }
-    });
-  },
-
-  /**
-    Load image for pattern.
-
-    @method _setPattern
-  */
-  _setPattern(style, i, index = null) {
-    return new Ember.RSVP.Promise((resolve) => {
-      let image = new Image();
-      Ember.set(style, 'pattern', true);
-      image.onload = function() {
-        Ember.set(style, 'imagePattern', this);
-        let result = {};
-        if (Ember.isNone(index)) {
-          result[i] = this;
-        } else {
-          let inner = {};
-          inner[i] = this;
-          result[index] = inner;
-        }
-
-        return resolve(result);
-      };
-
-      image.src = style.fillPattern;
-    });
-  },
-
-  /**
-    Destroys leaflet layer related to layer type.
-
-    @method destroyLayer
-  */
-  destroyLayer() {
-    let leafletLayer = this.get('_leafletObject');
-    if (leafletLayer instanceof L.MarkerClusterGroup) {
-      this.destroyClusterLayer(leafletLayer);
-    }
-  },
-
-  /**
-    Handles 'flexberry-map:identify' event of leaflet map.
-
-    @method identify
-    @param {Object} e Event object.
-    @param {<a href="http://leafletjs.com/reference.html#polygon">L.Polygon</a>} polygonLayer Polygon layer related to given area.
-    @param {Object[]} layers Objects describing those layers which must be identified.
-    @param {Object[]} results Objects describing identification results.
-    Every result-object has the following structure: { layer: ..., features: [...] },
-    where 'layer' is metadata of layer related to identification result, features is array
-    containing (GeoJSON feature-objects)[http://geojson.org/geojson-spec.html#feature-objects]
-    or a promise returning such array.
-  */
-  identify(e) {
-    let primitiveSatisfiesBounds = (primitive, bounds) => {
-      let satisfiesBounds = false;
-
-      if (typeof primitive.forEach === 'function') {
-        primitive.forEach(function (nestedGeometry, index) {
-          if (satisfiesBounds) {
-            return;
-          }
-
-          let nestedPrimitive = this.get(index);
-          satisfiesBounds = primitiveSatisfiesBounds(nestedPrimitive, bounds);
         });
       } else {
-        satisfiesBounds = primitive.within(bounds) || primitive.intersects(bounds);
+        resolve(resultLayer);
+      }
+    }).catch((e) => {
+      reject(e);
+    });
+  });
+},
+
+/**
+  Add in array promise which load pattern from styleSettings.
+
+  @method _imageFromStyleSettings
+*/
+_imageFromStyleSettings(imagePromises, styleSettings, index) {
+  if (styleSettings.style.path) {
+    if (Ember.isArray(styleSettings.style.path)) {
+      styleSettings.style.path.forEach((style, i) => {
+        if (style.fillStyle === 'pattern') {
+          imagePromises.addObject(this._setPattern(style, i, index));
+        }
+      });
+    } else if (styleSettings.style.path.fillStyle === 'pattern') {
+      imagePromises.addObject(this._setPattern(styleSettings.style.path, 0, index));
+    }
+  }
+},
+
+/**
+  For each styleRules load pattern.
+
+  @method _imageFromStyleRules
+*/
+_imageFromStyleRules(imagePromises) {
+  let styleRules = this.get('styleRules');
+  if (Ember.isNone(styleRules)) {
+    return;
+  }
+
+  styleRules.forEach((styleRule, i) => {
+    this._imageFromStyleSettings(imagePromises, styleRule.styleSettings, i);
+  });
+},
+
+/**
+  Change styleSettings depending on the zoom.
+
+  @method _updateStyleRules
+*/
+_updateStyleRules() {
+  let styleRules = this.get('styleRules');
+  if (Ember.isNone(styleRules)) {
+    return;
+  }
+
+  let leafletMap = this.get('leafletMap');
+  styleRules.forEach(styleRule => {
+    let rule = styleRule.rule;
+    let caption = `${this.get('i18n').t('components.base-vector-layer.zoomFrom').string} ${rule.minZoom}
+        ${this.get('i18n').t('components.base-vector-layer.zoomTo').string} ${rule.maxZoom}`;
+    Ember.set(rule, 'caption', caption);
+    if (checkMapZoomStyle(leafletMap, styleRule.rule) && this.get('styleSettings') !== styleRule.styleSettings) {
+      this.set('styleSettings', styleRule.styleSettings);
+    }
+  });
+},
+
+/**
+  Load image for pattern.
+
+  @method _setPattern
+*/
+_setPattern(style, i, index = null) {
+  return new Ember.RSVP.Promise((resolve) => {
+    let image = new Image();
+    Ember.set(style, 'pattern', true);
+    image.onload = function () {
+      Ember.set(style, 'imagePattern', this);
+      let result = {};
+      if (Ember.isNone(index)) {
+        result[i] = this;
+      } else {
+        let inner = {};
+        inner[i] = this;
+        result[index] = inner;
       }
 
-      return satisfiesBounds;
+      return resolve(result);
     };
 
-    return new Ember.RSVP.Promise((resolve, reject) => {
-      try {
-        let features = Ember.A();
-        let bounds = new Terraformer.Primitive(e.polygonLayer.toGeoJSON());
-        let leafletLayer = this.returnLeafletObject();
-        let mapModel = this.get('mapApi').getFromApi('mapModel');
-        let scale = this.get('mapApi').getFromApi('precisionScale');
-        leafletLayer.eachLayer(function (layer) {
-          let geoLayer = layer.toGeoJSON();
-          let primitive = new Terraformer.Primitive(geoLayer.geometry);
-
-          if (primitiveSatisfiesBounds(primitive, bounds)) {
-            if (geoLayer.geometry.type === 'GeometryCollection') {
-              geoLayer.geometry.geometries.forEach(feat => {
-                let geoObj = { type: 'Feature', geometry: feat };
-                features.pushObject(featureWithAreaIntersect(e.polygonLayer.toGeoJSON(), geoObj, leafletLayer, mapModel, scale));
-              });
-            } else {
-              features.pushObject(featureWithAreaIntersect(e.polygonLayer.toGeoJSON(), geoLayer, leafletLayer, mapModel, scale));
-            }
-          }
-        });
-
-        resolve(features);
-      } catch (e) {
-        reject(e.error || e);
-      }
-    });
-  },
-
-  /**
-    Handles 'flexberry-map:search' event of leaflet map.
-
-    @method search
-    @param {Object} e Event object.
-    @param {<a href="http://leafletjs.com/reference-1.0.0.html#latlng">L.LatLng</a>} e.latlng Center of the search area.
-    @param {Object[]} layer Object describing layer that must be searched.
-    @param {Object} searchOptions Search options related to layer type.
-    @param {Object} results Hash containing search results.
-    @param {Object[]} results.features Array containing (GeoJSON feature-objects)[http://geojson.org/geojson-spec.html#feature-objects]
-    or a promise returning such array.
-  */
-  search(e) {
-    return new Ember.RSVP.Promise((resolve, reject) => {
-      let searchSettingsPath = 'layerModel.settingsAsObject.searchSettings';
-      let leafletLayer = this.returnLeafletObject();
-      let features = Ember.A();
-
-      let searchFields = (e.context ? this.get(`${searchSettingsPath}.contextSearchFields`) : this.get(`${searchSettingsPath}.searchFields`)) || Ember.A();
-
-      // If single search field provided - transform it into array.
-      if (!Ember.isArray(searchFields)) {
-        searchFields = Ember.A([searchFields]);
-      }
-
-      leafletLayer.eachLayer((layer) => {
-        if (features.length < e.searchOptions.maxResultsCount) {
-          let feature = Ember.get(layer, 'feature');
-
-          // if layer satisfies search query
-          let contains = false;
-          searchFields.forEach((field) => {
-            if (feature && (feature.properties[field])) {
-              contains = contains || feature.properties[field].toLowerCase().includes(e.searchOptions.queryString.toLowerCase());
-            }
-          });
-
-          if (contains) {
-            let foundFeature = layer.toGeoJSON();
-            foundFeature.leafletLayer = L.geoJson(foundFeature);
-            features.pushObject(foundFeature);
-          }
-        }
-      });
-      resolve(features);
-    });
-  },
-
-  /**
-    Handles 'flexberry-map:query' event of leaflet map.
-
-    @method _query
-    @param {Object} e Event object.
-    @param {Object} queryFilter Object with query filter paramteres
-    @param {Object[]} results.features Array containing leaflet layers objects
-    or a promise returning such array.
-  */
-  query(layerLinks, e) {
-    return new Ember.RSVP.Promise((resolve, reject) => {
-      let queryFilter = e.queryFilter;
-      let features = Ember.A();
-      let equals = [];
-
-      layerLinks.forEach((link) => {
-        let linkParameters = link.get('parameters');
-
-        if (Ember.isArray(linkParameters) && linkParameters.length > 0) {
-          linkParameters.forEach(linkParam => {
-            let property = linkParam.get('layerField');
-            let propertyValue = queryFilter[linkParam.get('queryKey')];
-
-            equals.push({ 'prop': property, 'value': propertyValue });
-          });
-        }
-      });
-
-      let leafletLayer = this.returnLeafletObject();
-      leafletLayer.eachLayer((layer) => {
-        let feature = Ember.get(layer, 'feature');
-        let meet = true;
-        equals.forEach((equal) => {
-          meet = meet && Ember.isEqual(feature.properties[equal.prop], equal.value);
-        });
-
-        if (meet) {
-          features.pushObject(layer.toGeoJSON());
-        }
-      });
-
-      resolve(features);
-    });
-  },
-
-  /**
-    Handles 'flexberry-map:loadLayerFeatures' event of leaflet map.
-
-    @method loadLayerFeatures
-    @param {Object} e Event object.
-    @returns {Ember.RSVP.Promise} Returns promise.
-  */
-  loadLayerFeatures(e) {
-    return new Ember.RSVP.Promise((resolve, reject) => {
-      resolve(this.returnLeafletObject());
-    });
-  },
-
-  /**
-    Handles 'flexberry-map:getLayerFeatures' event of leaflet map.
-
-    @method getLayerFeatures
-    @param {Object} e Event object.
-    @returns {Ember.RSVP.Promise} Returns promise.
-  */
-  getLayerFeatures(e) {
-    return new Ember.RSVP.Promise((resolve, reject) => {
-      let leafletObject = this.returnLeafletObject();
-      let featureIds = e.featureIds;
-      if (Ember.isArray(featureIds) && !Ember.isNone(featureIds)) {
-        let objects = [];
-        featureIds.forEach((id) => {
-          let features = leafletObject._layers;
-          let obj = Object.values(features).find(feature => {
-            return this.get('mapApi').getFromApi('mapModel')._getLayerFeatureId(this.get('layerModel'), feature) === id;
-          });
-          if (!Ember.isNone(obj)) {
-            objects.push(obj);
-          }
-        });
-        resolve(objects);
-      } else {
-        resolve(Object.values(leafletObject._layers));
-      }
-    });
-  },
-
-  /**
-    Handles 'flexberry-map:getOrLoadLayerFeatures' event of leaflet map.
-
-    @method _getOrLoadLayerFeatures
-    @param {Object} e Event object.
-    @returns {Object[]} results Objects.
-  */
-  _getOrLoadLayerFeatures(e) {
-    if (this.get('layerModel.id') !== e.layer) {
-      return;
-    }
-
-    e.results.push({
-      layerModel: this.get('layerModel'),
-      leafletObject: this.returnLeafletObject(),
-      features: e.load ? this.loadLayerFeatures(e) : this.getLayerFeatures(e)
-    });
-  },
-
-  /**
-    Handles zoomend
-  */
-  continueLoad() {
-  },
-
-  /**
-    Handles 'flexberry-map:continueLoad' event of leaflet map.
-
-    @method search
-    @param {Object} e Event object.
-    @param {Object} layerModel Object describing layer that must be continueLoad.
-    @param {Object} results Hash containing promise.
-  */
-  _continueLoad(e) {
-    let shouldContinueLoad = Ember.A(e.layers || []).contains(this.get('layerModel'));
-    if (!shouldContinueLoad) {
-      return;
-    }
-
-    // Call public identify method, if layer should be continueLoad.
-    e.results.push({
-      layerModel: this.get('layerModel'),
-      promise: this.continueLoad(this.returnLeafletObject())
-    });
-  },
-
-  /*
-    Clear changes. Needs for CancelEdit and Reload
-  */
-  clearChanges() {
-  },
-
-  reload() {
-    this.clearChanges();
-
-    let leafletObject = this.returnLeafletObject();
-    let map = this.get('leafletMap');
-
-    leafletObject.eachLayer((layerShape) => {
-      if (map.hasLayer(layerShape)) {
-        map.removeLayer(layerShape);
-      }
-    });
-    leafletObject.clearLayers();
-
-    this.reloadLabel(leafletObject);
-
-    this.set('loadedBounds', null);
-    let load = this.continueLoad();
-
-    return load && load instanceof Ember.RSVP.Promise ? load : Ember.RSVP.resolve();
-  },
-
-  /**
-    Adds a listener function to leafletMap.
-
-    @method onLeafletMapEvent
-    @return nothing.
-  */
-  onLeafletMapEvent() {
-    let leafletMap = this.get('leafletMap');
-    if (!Ember.isNone(leafletMap)) {
-      leafletMap.on('flexberry-map:getOrLoadLayerFeatures', this._getOrLoadLayerFeatures, this);
-      leafletMap.on('zoomend', this._checkZoomPane, this);
-    }
-  },
-
-  /**
-    Initializes DOM-related component's properties.
-  */
-  didInsertElement() {
-    this._super(...arguments);
-    this.onLeafletMapEvent();
-  },
-
-  /**
-    Switches pane depending on the zoom.
-
-    @method _checkZoomPane
-    @private
-  */
-  _checkZoomPane() {
-    let leafletObject = this.returnLeafletObject();
-    let thisPane = this.get('_pane');
-    let leafletMap = this.get('leafletMap');
-    if (!Ember.isNone(leafletMap) && thisPane && !Ember.isNone(leafletObject)) {
-      let pane = leafletMap.getPane(thisPane);
-      let mapPane = leafletMap._mapPane;
-      if (!Ember.isNone(mapPane) && !Ember.isNone(pane)) {
-
-        let styleRules = this.get('styleRules');
-        let styleZoom = Ember.A();
-        if (!Ember.isNone(styleRules) && styleRules.length > 0) {
-          styleZoom = styleRules.filter(styleRule => {
-            return checkMapZoomStyle(leafletMap, styleRule.rule);
-          });
-        } else {
-          if (checkMapZoom(leafletObject)) {
-            styleZoom.addObject({});
-          }
-        }
-
-        let existPaneDomElem = Ember.$(mapPane).children(`[class*='${thisPane}']`).length;
-        if (existPaneDomElem > 0 && styleZoom.length === 0) {
-          L.DomUtil.remove(pane);
-        } else if (existPaneDomElem === 0 && styleZoom.length > 0) {
-          mapPane.appendChild(pane);
-        }
-      }
-    }
-
-    this._checkZoomPaneLabel(leafletObject);
-  },
-
-  /**
-    Deinitializes DOM-related component's properties.
-  */
-  willDestroyElement() {
-    this._super(...arguments);
-
-    let leafletMap = this.get('leafletMap');
-    if (!Ember.isNone(leafletMap)) {
-      leafletMap.off('flexberry-map:getOrLoadLayerFeatures', this._getOrLoadLayerFeatures, this);
-
-      if (this.get('typeGeometry') === 'polyline') {
-        leafletMap.off('zoomend', this._updatePositionLabelForLine, this);
-      }
-
-      if (this.get('showExisting') !== false) {
-        leafletMap.off('moveend', this._showLabelsMovingMap, this);
-      }
-
-      let styleRules = this.get('layerModel.settingsAsObject.styleRules');
-      if (styleRules.length > 0) {
-        leafletMap.off('zoomend', this._updateStyleRules, this);
-      }
-
-      this.willDestroyElementLabel(leafletMap);
-    }
-  },
-
-  _createLayer() {
-    this._super(...arguments);
-
-    this.get('_leafletLayerPromise').then((leafletLayer) => {
-      this._checkZoomPane();
-    });
-  },
-
-  /**
-    Sets leaflet layer's visibility.
-
-    @method _setLayerVisibility
-    @private
-  */
-  _setLayerVisibility() {
-    if (this.get('visibility')) {
-      this._addLayerToLeafletContainer();
-      if (this.typeGeometry === 'marker' && !this.clusterize) {
-        this._setLayerStyle();
-      }
-
-      let leafletObject = this.returnLeafletObject();
-      this._setLayerVisibilityLabel(leafletObject);
-    } else {
-      this._removeLayerFromLeafletContainer();
-      this._removeLabelsFromLeafletContainer();
-    }
-  },
-
-  /**
-    Gets feature properties as plain object.
-    this is necessary to get properties from odata-vector-layer feature
-
-    @method _setLayerVisibility
-    @private
-  */
-  _getRegularProperties() {
-    if (!this || !Ember.get(this, 'feature') || !Ember.get(this, 'feature.properties')) {
-      return null;
-    }
-
-    return Ember.get(this, 'feature.properties');
-  },
-
-  _getGeometry(layer) {
-    let geoJSONLayer = layer.toProjectedGeoJSON(this.get('crs'));
-    let type = layer.toGeoJSON().geometry.type;
-    let forceMulti = this.get('forceMulti') || false;
-
-    if (forceMulti && (type === 'Polygon' || type === 'LineString')) {
-      return [geoJSONLayer.geometry.coordinates];
-    } else {
-      return geoJSONLayer.geometry.coordinates;
-    }
-  },
-
-  _boundsCrs(leafletObject) {
-    let leafletMap = this.get('leafletMap');
-    let boundsMap = leafletMap.getBounds();
-    if (boundsMap && leafletObject.options && leafletObject.options.crs && leafletObject.options.crs.bounds) {
-      let crsBounds = leafletObject.options.crs.bounds;
-      if (boundsMap._northEast.lat > crsBounds.max.x) {
-        boundsMap._northEast.lat = crsBounds.max.x;
-      }
-
-      if (boundsMap._northEast.lng > crsBounds.max.y) {
-        boundsMap._northEast.lng = crsBounds.max.y;
-      }
-
-      if ((boundsMap._southWest.lat < 0 && boundsMap._southWest.lat < crsBounds.min.x) ||
-        (boundsMap._southWest.lat > 0 && boundsMap._southWest.lat > crsBounds.min.x)) {
-        boundsMap._southWest.lat = crsBounds.min.x;
-      }
-
-      if ((boundsMap._southWest.lng < 0 && boundsMap._southWest.lng < crsBounds.min.y) ||
-        (boundsMap._southWest.lng > 0 && boundsMap._southWest.lng > crsBounds.min.y)) {
-        boundsMap._southWest.lng = crsBounds.min.y;
-      }
-    }
-
-    return boundsMap;
+    image.src = style.fillPattern;
+  });
+},
+
+/**
+  Destroys leaflet layer related to layer type.
+
+  @method destroyLayer
+*/
+destroyLayer() {
+  let leafletLayer = this.get('_leafletObject');
+  if (leafletLayer instanceof L.MarkerClusterGroup) {
+    this.destroyClusterLayer(leafletLayer);
   }
+},
+
+/**
+  Handles 'flexberry-map:identify' event of leaflet map.
+
+  @method identify
+  @param {Object} e Event object.
+  @param {<a href="http://leafletjs.com/reference.html#polygon">L.Polygon</a>} polygonLayer Polygon layer related to given area.
+  @param {Object[]} layers Objects describing those layers which must be identified.
+  @param {Object[]} results Objects describing identification results.
+  Every result-object has the following structure: { layer: ..., features: [...] },
+  where 'layer' is metadata of layer related to identification result, features is array
+  containing (GeoJSON feature-objects)[http://geojson.org/geojson-spec.html#feature-objects]
+  or a promise returning such array.
+*/
+identify(e) {
+  let primitiveSatisfiesBounds = (primitive, bounds) => {
+    let satisfiesBounds = false;
+
+    if (typeof primitive.forEach === 'function') {
+      primitive.forEach(function (nestedGeometry, index) {
+        if (satisfiesBounds) {
+          return;
+        }
+
+        let nestedPrimitive = this.get(index);
+        satisfiesBounds = primitiveSatisfiesBounds(nestedPrimitive, bounds);
+      });
+    } else {
+      satisfiesBounds = primitive.within(bounds) || primitive.intersects(bounds);
+    }
+
+    return satisfiesBounds;
+  };
+
+  return new Ember.RSVP.Promise((resolve, reject) => {
+    try {
+      let features = Ember.A();
+      let bounds = new Terraformer.Primitive(e.polygonLayer.toGeoJSON());
+      let leafletLayer = this.returnLeafletObject();
+      let mapModel = this.get('mapApi').getFromApi('mapModel');
+      let scale = this.get('mapApi').getFromApi('precisionScale');
+      leafletLayer.eachLayer(function (layer) {
+        let geoLayer = layer.toGeoJSON();
+        let primitive = new Terraformer.Primitive(geoLayer.geometry);
+
+        if (primitiveSatisfiesBounds(primitive, bounds)) {
+          if (geoLayer.geometry.type === 'GeometryCollection') {
+            geoLayer.geometry.geometries.forEach(feat => {
+              let geoObj = { type: 'Feature', geometry: feat };
+              features.pushObject(featureWithAreaIntersect(e.polygonLayer.toGeoJSON(), geoObj, leafletLayer, mapModel, scale));
+            });
+          } else {
+            features.pushObject(featureWithAreaIntersect(e.polygonLayer.toGeoJSON(), geoLayer, leafletLayer, mapModel, scale));
+          }
+        }
+      });
+
+      resolve(features);
+    } catch (e) {
+      reject(e.error || e);
+    }
+  });
+},
+
+/**
+  Handles 'flexberry-map:search' event of leaflet map.
+
+  @method search
+  @param {Object} e Event object.
+  @param {<a href="http://leafletjs.com/reference-1.0.0.html#latlng">L.LatLng</a>} e.latlng Center of the search area.
+  @param {Object[]} layer Object describing layer that must be searched.
+  @param {Object} searchOptions Search options related to layer type.
+  @param {Object} results Hash containing search results.
+  @param {Object[]} results.features Array containing (GeoJSON feature-objects)[http://geojson.org/geojson-spec.html#feature-objects]
+  or a promise returning such array.
+*/
+search(e) {
+  return new Ember.RSVP.Promise((resolve, reject) => {
+    let searchSettingsPath = 'layerModel.settingsAsObject.searchSettings';
+    let leafletLayer = this.returnLeafletObject();
+    let features = Ember.A();
+
+    let searchFields = (e.context ? this.get(`${searchSettingsPath}.contextSearchFields`) : this.get(`${searchSettingsPath}.searchFields`)) || Ember.A();
+
+    // If single search field provided - transform it into array.
+    if (!Ember.isArray(searchFields)) {
+      searchFields = Ember.A([searchFields]);
+    }
+
+    leafletLayer.eachLayer((layer) => {
+      if (features.length < e.searchOptions.maxResultsCount) {
+        let feature = Ember.get(layer, 'feature');
+
+        // if layer satisfies search query
+        let contains = false;
+        searchFields.forEach((field) => {
+          if (feature && (feature.properties[field])) {
+            contains = contains || feature.properties[field].toLowerCase().includes(e.searchOptions.queryString.toLowerCase());
+          }
+        });
+
+        if (contains) {
+          let foundFeature = layer.toGeoJSON();
+          foundFeature.leafletLayer = L.geoJson(foundFeature);
+          features.pushObject(foundFeature);
+        }
+      }
+    });
+    resolve(features);
+  });
+},
+
+/**
+  Handles 'flexberry-map:query' event of leaflet map.
+
+  @method _query
+  @param {Object} e Event object.
+  @param {Object} queryFilter Object with query filter paramteres
+  @param {Object[]} results.features Array containing leaflet layers objects
+  or a promise returning such array.
+*/
+query(layerLinks, e) {
+  return new Ember.RSVP.Promise((resolve, reject) => {
+    let queryFilter = e.queryFilter;
+    let features = Ember.A();
+    let equals = [];
+
+    layerLinks.forEach((link) => {
+      let linkParameters = link.get('parameters');
+
+      if (Ember.isArray(linkParameters) && linkParameters.length > 0) {
+        linkParameters.forEach(linkParam => {
+          let property = linkParam.get('layerField');
+          let propertyValue = queryFilter[linkParam.get('queryKey')];
+
+          equals.push({ 'prop': property, 'value': propertyValue });
+        });
+      }
+    });
+
+    let leafletLayer = this.returnLeafletObject();
+    leafletLayer.eachLayer((layer) => {
+      let feature = Ember.get(layer, 'feature');
+      let meet = true;
+      equals.forEach((equal) => {
+        meet = meet && Ember.isEqual(feature.properties[equal.prop], equal.value);
+      });
+
+      if (meet) {
+        features.pushObject(layer.toGeoJSON());
+      }
+    });
+
+    resolve(features);
+  });
+},
+
+/**
+  Handles 'flexberry-map:loadLayerFeatures' event of leaflet map.
+
+  @method loadLayerFeatures
+  @param {Object} e Event object.
+  @returns {Ember.RSVP.Promise} Returns promise.
+*/
+loadLayerFeatures(e) {
+  return new Ember.RSVP.Promise((resolve, reject) => {
+    resolve(this.returnLeafletObject());
+  });
+},
+
+/**
+  Handles 'flexberry-map:getLayerFeatures' event of leaflet map.
+
+  @method getLayerFeatures
+  @param {Object} e Event object.
+  @returns {Ember.RSVP.Promise} Returns promise.
+*/
+getLayerFeatures(e) {
+  return new Ember.RSVP.Promise((resolve, reject) => {
+    let leafletObject = this.returnLeafletObject();
+    let featureIds = e.featureIds;
+    if (Ember.isArray(featureIds) && !Ember.isNone(featureIds)) {
+      let objects = [];
+      featureIds.forEach((id) => {
+        let features = leafletObject._layers;
+        let obj = Object.values(features).find(feature => {
+          return this.get('mapApi').getFromApi('mapModel')._getLayerFeatureId(this.get('layerModel'), feature) === id;
+        });
+        if (!Ember.isNone(obj)) {
+          objects.push(obj);
+        }
+      });
+      resolve(objects);
+    } else {
+      resolve(Object.values(leafletObject._layers));
+    }
+  });
+},
+
+/**
+  Handles 'flexberry-map:getOrLoadLayerFeatures' event of leaflet map.
+
+  @method _getOrLoadLayerFeatures
+  @param {Object} e Event object.
+  @returns {Object[]} results Objects.
+*/
+_getOrLoadLayerFeatures(e) {
+  if (this.get('layerModel.id') !== e.layer) {
+    return;
+  }
+
+  e.results.push({
+    layerModel: this.get('layerModel'),
+    leafletObject: this.returnLeafletObject(),
+    features: e.load ? this.loadLayerFeatures(e) : this.getLayerFeatures(e)
+  });
+},
+
+/**
+  Handles zoomend
+*/
+continueLoad() {
+},
+
+/**
+  Handles 'flexberry-map:continueLoad' event of leaflet map.
+
+  @method search
+  @param {Object} e Event object.
+  @param {Object} layerModel Object describing layer that must be continueLoad.
+  @param {Object} results Hash containing promise.
+*/
+_continueLoad(e) {
+  let shouldContinueLoad = Ember.A(e.layers || []).contains(this.get('layerModel'));
+  if (!shouldContinueLoad) {
+    return;
+  }
+
+  // Call public identify method, if layer should be continueLoad.
+  e.results.push({
+    layerModel: this.get('layerModel'),
+    promise: this.continueLoad(this.returnLeafletObject())
+  });
+},
+
+/*
+  Clear changes. Needs for CancelEdit and Reload
+*/
+clearChanges() {
+},
+
+reload() {
+  this.clearChanges();
+
+  let leafletObject = this.returnLeafletObject();
+  let map = this.get('leafletMap');
+
+  leafletObject.eachLayer((layerShape) => {
+    if (map.hasLayer(layerShape)) {
+      map.removeLayer(layerShape);
+    }
+  });
+  leafletObject.clearLayers();
+
+  this.reloadLabel(leafletObject);
+
+  this.set('loadedBounds', null);
+  let load = this.continueLoad();
+
+  return load && load instanceof Ember.RSVP.Promise ? load : Ember.RSVP.resolve();
+},
+
+/**
+  Adds a listener function to leafletMap.
+
+  @method onLeafletMapEvent
+  @return nothing.
+*/
+onLeafletMapEvent() {
+  let leafletMap = this.get('leafletMap');
+  if (!Ember.isNone(leafletMap)) {
+    leafletMap.on('flexberry-map:getOrLoadLayerFeatures', this._getOrLoadLayerFeatures, this);
+    leafletMap.on('zoomend', this._checkZoomPane, this);
+  }
+},
+
+/**
+  Initializes DOM-related component's properties.
+*/
+didInsertElement() {
+  this._super(...arguments);
+  this.onLeafletMapEvent();
+},
+
+/**
+  Switches pane depending on the zoom.
+
+  @method _checkZoomPane
+  @private
+*/
+_checkZoomPane() {
+  let leafletObject = this.returnLeafletObject();
+  let thisPane = this.get('_pane');
+  let leafletMap = this.get('leafletMap');
+  if (!Ember.isNone(leafletMap) && thisPane && !Ember.isNone(leafletObject)) {
+    let pane = leafletMap.getPane(thisPane);
+    let mapPane = leafletMap._mapPane;
+    if (!Ember.isNone(mapPane) && !Ember.isNone(pane)) {
+
+      let styleRules = this.get('styleRules');
+      let styleZoom = Ember.A();
+      if (!Ember.isNone(styleRules) && styleRules.length > 0) {
+        styleZoom = styleRules.filter(styleRule => {
+          return checkMapZoomStyle(leafletMap, styleRule.rule);
+        });
+      } else {
+        if (checkMapZoom(leafletObject)) {
+          styleZoom.addObject({});
+        }
+      }
+
+      let existPaneDomElem = Ember.$(mapPane).children(`[class*='${thisPane}']`).length;
+      if (existPaneDomElem > 0 && styleZoom.length === 0) {
+        L.DomUtil.remove(pane);
+      } else if (existPaneDomElem === 0 && styleZoom.length > 0) {
+        mapPane.appendChild(pane);
+      }
+    }
+  }
+
+  this._checkZoomPaneLabel(leafletObject);
+},
+
+/**
+  Deinitializes DOM-related component's properties.
+*/
+willDestroyElement() {
+  this._super(...arguments);
+
+  let leafletMap = this.get('leafletMap');
+  if (!Ember.isNone(leafletMap)) {
+    leafletMap.off('flexberry-map:getOrLoadLayerFeatures', this._getOrLoadLayerFeatures, this);
+
+    if (this.get('typeGeometry') === 'polyline') {
+      leafletMap.off('zoomend', this._updatePositionLabelForLine, this);
+    }
+
+    if (this.get('showExisting') !== false) {
+      leafletMap.off('moveend', this._showLabelsMovingMap, this);
+    }
+
+    let styleRules = this.get('layerModel.settingsAsObject.styleRules');
+    if (styleRules.length > 0) {
+      leafletMap.off('zoomend', this._updateStyleRules, this);
+    }
+
+    this.willDestroyElementLabel(leafletMap);
+  }
+},
+
+_createLayer() {
+  this._super(...arguments);
+
+  this.get('_leafletLayerPromise').then((leafletLayer) => {
+    this._checkZoomPane();
+  });
+},
+
+/**
+  Sets leaflet layer's visibility.
+
+  @method _setLayerVisibility
+  @private
+*/
+_setLayerVisibility() {
+  if (this.get('visibility')) {
+    this._addLayerToLeafletContainer();
+    if (this.typeGeometry === 'marker' && !this.clusterize) {
+      this._setLayerStyle();
+    }
+
+    let leafletObject = this.returnLeafletObject();
+    this._setLayerVisibilityLabel(leafletObject);
+  } else {
+    this._removeLayerFromLeafletContainer();
+    this._removeLabelsFromLeafletContainer();
+  }
+},
+
+/**
+  Gets feature properties as plain object.
+  this is necessary to get properties from odata-vector-layer feature
+
+  @method _setLayerVisibility
+  @private
+*/
+_getRegularProperties() {
+  if (!this || !Ember.get(this, 'feature') || !Ember.get(this, 'feature.properties')) {
+    return null;
+  }
+
+  return Ember.get(this, 'feature.properties');
+},
+
+_getGeometry(layer) {
+  let geoJSONLayer = layer.toProjectedGeoJSON(this.get('crs'));
+  let type = layer.toGeoJSON().geometry.type;
+  let forceMulti = this.get('forceMulti') || false;
+
+  if (forceMulti && (type === 'Polygon' || type === 'LineString')) {
+    return [geoJSONLayer.geometry.coordinates];
+  } else {
+    return geoJSONLayer.geometry.coordinates;
+  }
+},
+
+_boundsCrs(leafletObject) {
+  let leafletMap = this.get('leafletMap');
+  let boundsMap = leafletMap.getBounds();
+  if (boundsMap && leafletObject.options && leafletObject.options.crs && leafletObject.options.crs.bounds) {
+    let crsBounds = leafletObject.options.crs.bounds;
+    if (boundsMap._northEast.lat > crsBounds.max.x) {
+      boundsMap._northEast.lat = crsBounds.max.x;
+    }
+
+    if (boundsMap._northEast.lng > crsBounds.max.y) {
+      boundsMap._northEast.lng = crsBounds.max.y;
+    }
+
+    if ((boundsMap._southWest.lat < 0 && boundsMap._southWest.lat < crsBounds.min.x) ||
+      (boundsMap._southWest.lat > 0 && boundsMap._southWest.lat > crsBounds.min.x)) {
+      boundsMap._southWest.lat = crsBounds.min.x;
+    }
+
+    if ((boundsMap._southWest.lng < 0 && boundsMap._southWest.lng < crsBounds.min.y) ||
+      (boundsMap._southWest.lng > 0 && boundsMap._southWest.lng > crsBounds.min.y)) {
+      boundsMap._southWest.lng = crsBounds.min.y;
+    }
+  }
+
+  return boundsMap;
+}
 });

--- a/addon/components/feature-result-item.js
+++ b/addon/components/feature-result-item.js
@@ -510,7 +510,7 @@ export default Ember.Component.extend(SlotsMixin, ResultFeatureInitializer, {
             leafletMap.removeLayer(objectFirst)
 
           // Удаляем исходный объект слоя
-          leafletMap.removeLayer(object)
+          leafletMap.removeLayer(feature.leafletLayer);
           // Так как во время редактирования будет создан дубликат исходного объекта на сервисном слое
 
           this.sendAction('editFeature', {

--- a/addon/components/feature-result-item.js
+++ b/addon/components/feature-result-item.js
@@ -511,8 +511,8 @@ export default Ember.Component.extend(SlotsMixin, ResultFeatureInitializer, {
           }
 
           // Удаляем исходный объект слоя
-          leafletMap.removeLayer(feature.leafletLayer);
           // Так как во время редактирования будет создан дубликат исходного объекта на сервисном слое
+          leafletMap.removeLayer(feature.leafletLayer);
 
           this.sendAction('editFeature', {
             isFavorite: feature.properties.isFavorite,

--- a/addon/components/feature-result-item.js
+++ b/addon/components/feature-result-item.js
@@ -506,8 +506,9 @@ export default Ember.Component.extend(SlotsMixin, ResultFeatureInitializer, {
           };
 
           // Для слоев типа wms-wfs удаляем исходный объект wms-тайл
-          if (objectFirst)
-            leafletMap.removeLayer(objectFirst)
+          if (objectFirst) {
+            leafletMap.removeLayer(objectFirst);
+          }
 
           // Удаляем исходный объект слоя
           leafletMap.removeLayer(feature.leafletLayer);

--- a/addon/components/feature-result-item.js
+++ b/addon/components/feature-result-item.js
@@ -466,7 +466,7 @@ export default Ember.Component.extend(SlotsMixin, ResultFeatureInitializer, {
 
       this.set('_showLoader', true);
 
-      getAttributesOptions().then(({ object, settings }) => {
+      getAttributesOptions().then(({ objectFirst, object, settings }) => {
         let name = Ember.get(layerModel, 'name');
 
         // редактируемый объект должен быть загружен
@@ -505,7 +505,14 @@ export default Ember.Component.extend(SlotsMixin, ResultFeatureInitializer, {
             }]
           };
 
-          leafletMap.removeLayer(feature.leafletLayer);
+          // Для слоев типа wms-wfs удаляем исходный объект wms-тайл
+          if (objectFirst)
+            leafletMap.removeLayer(objectFirst)
+
+          // Удаляем исходный объект слоя
+          leafletMap.removeLayer(object)
+          // Так как во время редактирования будет создан дубликат исходного объекта на сервисном слое
+
           this.sendAction('editFeature', {
             isFavorite: feature.properties.isFavorite,
             dataItems: dataItems,
@@ -665,7 +672,7 @@ export default Ember.Component.extend(SlotsMixin, ResultFeatureInitializer, {
     let leafletMap = this.get('mapApi').getFromApi('leafletMap');
     let resultObject = this.get('resultObject'); // parent result object from layer-result-list
 
-    if (editedLayer && editedLayerId ===  resultObject.layerModel.id && editedFeature && editedFeatureId === feature.id) {
+    if (editedLayer && editedLayerId === resultObject.layerModel.id && editedFeature && editedFeatureId === feature.id) {
       // on successfull edit
       Object.keys(editedFeature.feature.properties).forEach(attribute => {
         if (attribute === 'primarykey') {
@@ -676,7 +683,7 @@ export default Ember.Component.extend(SlotsMixin, ResultFeatureInitializer, {
       });
       Ember.set(feature, 'displayValue', this.getFeatureDisplayProperty(feature, resultObject.settings));
 
-      if (typeof editedFeature.getLatLngs  === 'function') {
+      if (typeof editedFeature.getLatLngs === 'function') {
         feature.leafletLayer.setLatLngs(editedFeature.getLatLngs()); // Update feature geometry
       } else {
         feature.leafletLayer.setLatLng(editedFeature.getLatLng());

--- a/addon/components/flexberry-edit-layer-feature.js
+++ b/addon/components/flexberry-edit-layer-feature.js
@@ -1291,6 +1291,12 @@ export default Ember.Component.extend(SnapDrawMixin, LeafletZoomToFeatureMixin, 
           !Ember.isNone(_leafletObjectFirst) &&
           typeof _leafletObjectFirst.setParams === 'function'
         ) {
+
+          // Возвращаем wms часть слоя wms-wfs на карту при сохранение, которую удаляли при редактировании feature
+          if (!leafletMap.hasLayer(_leafletObjectFirst)) {
+            leafletMap.addLayer(_leafletObjectFirst)
+          }
+
           this.trancateGeoWebCache(_leafletObjectFirst, leafletMap);
           _leafletObjectFirst.setParams({ fake: Date.now() }, false);
         }

--- a/addon/components/flexberry-edit-layer-feature.js
+++ b/addon/components/flexberry-edit-layer-feature.js
@@ -908,6 +908,13 @@ export default Ember.Component.extend(SnapDrawMixin, LeafletZoomToFeatureMixin, 
       this.send('clearSelected');
     }
 
+
+    let _leafletObjectFirst = this.get('layerModel.layerModel._leafletObjectFirst');
+    // Возвращаем wms часть слоя wms-wfs на карту при сохранение, которую удаляли при редактировании feature
+    if (!leafletMap.hasLayer(_leafletObjectFirst)) {
+      leafletMap.addLayer(_leafletObjectFirst)
+    }
+
     this.set('latlngs', null);
     this.set('layers', null);
     this.set('isLayerCopy', false);

--- a/addon/components/flexberry-edit-layer-feature.js
+++ b/addon/components/flexberry-edit-layer-feature.js
@@ -911,7 +911,7 @@ export default Ember.Component.extend(SnapDrawMixin, LeafletZoomToFeatureMixin, 
     // Возвращаем wms часть слоя wms-wfs на карту при сохранение, которую удаляли при редактировании feature
     let _leafletObjectFirst = this.get('layerModel.layerModel._leafletObjectFirst');
     if (!Ember.isNone(_leafletObjectFirst) && !leafletMap.hasLayer(_leafletObjectFirst)) {
-      leafletMap.addLayer(_leafletObjectFirst)
+      leafletMap.addLayer(_leafletObjectFirst);
     }
 
     this.set('latlngs', null);
@@ -1300,7 +1300,7 @@ export default Ember.Component.extend(SnapDrawMixin, LeafletZoomToFeatureMixin, 
 
           // Возвращаем wms часть слоя wms-wfs на карту при сохранение, которую удаляли при редактировании feature
           if (!leafletMap.hasLayer(_leafletObjectFirst)) {
-            leafletMap.addLayer(_leafletObjectFirst)
+            leafletMap.addLayer(_leafletObjectFirst);
           }
 
           this.trancateGeoWebCache(_leafletObjectFirst, leafletMap);

--- a/addon/components/flexberry-edit-layer-feature.js
+++ b/addon/components/flexberry-edit-layer-feature.js
@@ -908,10 +908,9 @@ export default Ember.Component.extend(SnapDrawMixin, LeafletZoomToFeatureMixin, 
       this.send('clearSelected');
     }
 
-
-    let _leafletObjectFirst = this.get('layerModel.layerModel._leafletObjectFirst');
     // Возвращаем wms часть слоя wms-wfs на карту при сохранение, которую удаляли при редактировании feature
-    if (!leafletMap.hasLayer(_leafletObjectFirst)) {
+    let _leafletObjectFirst = this.get('layerModel.layerModel._leafletObjectFirst');
+    if (!Ember.isNone(_leafletObjectFirst) && !leafletMap.hasLayer(_leafletObjectFirst)) {
       leafletMap.addLayer(_leafletObjectFirst)
     }
 

--- a/addon/components/geometry-add-modes/draw.js
+++ b/addon/components/geometry-add-modes/draw.js
@@ -124,7 +124,7 @@ let FlexberryGeometryAddModeDrawComponent = Ember.Component.extend({
     @method _validFloatNumber
   */
   _validOffset(str) {
-    const regex = /^(([0-9]*[.])?[0-9]+)$/;
+    const regex = /^-?([0-9]*[.])?[0-9]+$/;
     return regex.exec(str);
   },
 

--- a/addon/components/layers/odata-vector-layer.js
+++ b/addon/components/layers/odata-vector-layer.js
@@ -67,7 +67,7 @@ export default BaseVectorLayer.extend(OdataFilterParserMixin, {
       }
     }, leafletObject);
 
-    let modelsLayer = leafletObject.models;
+    let modelsLayer = Object.values(leafletObject.models);
     if (modelsLayer.length > 0) {
       let insertedIds = leafletObject.getLayers().map((layer) => {
         if (layer.state === state.insert) {
@@ -85,7 +85,7 @@ export default BaseVectorLayer.extend(OdataFilterParserMixin, {
       // to send request via the needed adapter
       let obj = this.get('_adapterStoreModelProjectionGeom');
       obj.adapter.batchUpdate(obj.store, modelsLayer).then((models) => {
-        modelsLayer.clear();
+        Ember.set(leafletObject, 'models', Ember.Object.create({}));
         let insertedModelId = [];
         if (!Ember.isNone(updatedLayers) && updatedLayers.length > 0) {
           updatedLayers.map((layer) => {
@@ -1040,7 +1040,7 @@ export default BaseVectorLayer.extend(OdataFilterParserMixin, {
     layer.projectionName = obj.projectionName;
     layer.editformname = obj.modelName + this.get('postfixForEditForm');
     layer.loadLayerFeatures = this.get('loadLayerFeatures').bind(this);
-    layer.models = Ember.A();
+    layer.models = Ember.Object.create({});
     layer.clearLayers = this.get('clearLayers').bind(this);
     layer.cancelEdit = this.get('cancelEdit').bind(this);
     layer.updateLabel = this.get('updateLabel').bind(this);
@@ -1732,61 +1732,58 @@ export default BaseVectorLayer.extend(OdataFilterParserMixin, {
     let editTools = leafletObject.leafletMap.editTools;
 
     let featuresIds = [];
-    let changes = leafletObject.models.filter((item) => true); // for check empty
-    if (!Ember.isEmpty(changes)) {
-      Object.entries(leafletObject.models)
-        .filter((item) => { return Ember.isNone(ids) || ids.contains(leafletObject.getLayerId(leafletObject.getLayer(item[0]))); })
-        .map((item) => item[1])
-        .forEach((model, index) => {
-          if (model instanceof Ember.Object) {
-            let layer = Object.values(leafletObject._layers).find((layer) => {
-              if (layer.model.get('id') === model.get('id')) {
-                return layer;
-              }
-            });
+    Object.entries(leafletObject.models)
+      .filter((item) => { return Ember.isNone(ids) || ids.contains(leafletObject.getLayerId(leafletObject.getLayer(item[0]))); })
+      .map((item) => item[1])
+      .forEach((model, index) => {
+        if (model instanceof Ember.Object) {
+          let layer = Object.values(leafletObject._layers).find((layer) => {
+            if (layer.model.get('id') === model.get('id')) {
+              return layer;
+            }
+          });
 
-            let dirtyType = model.get('dirtyType');
-            if (dirtyType === 'created') {
+          let dirtyType = model.get('dirtyType');
+          if (dirtyType === 'created') {
+            if (leafletObject.hasLayer(layer)) {
+              leafletObject.removeLayer(layer);
+            }
+
+            delete leafletObject.models[index];
+            if (editTools.featuresLayer.getLayers().length !== 0) {
+              let editorLayerId = editTools.featuresLayer.getLayerId(layer);
+              let featureLayer = editTools.featuresLayer.getLayer(editorLayerId);
+              if (!Ember.isNone(editorLayerId) && !Ember.isNone(featureLayer) && !Ember.isNone(featureLayer.editor)) {
+                let editLayer = featureLayer.editor.editLayer;
+                editTools.editLayer.removeLayer(editLayer);
+                editTools.featuresLayer.removeLayer(layer);
+              }
+            }
+          } else if (dirtyType === 'updated' || dirtyType === 'deleted') {
+            if (!Ember.isNone(layer)) {
+              if (!Ember.isNone(layer.editor)) {
+                let editLayer = layer.editor.editLayer;
+                editTools.editLayer.removeLayer(editLayer);
+              }
+
               if (leafletObject.hasLayer(layer)) {
                 leafletObject.removeLayer(layer);
               }
-
-              delete leafletObject.models[index];
-              if (editTools.featuresLayer.getLayers().length !== 0) {
-                let editorLayerId = editTools.featuresLayer.getLayerId(layer);
-                let featureLayer = editTools.featuresLayer.getLayer(editorLayerId);
-                if (!Ember.isNone(editorLayerId) && !Ember.isNone(featureLayer) && !Ember.isNone(featureLayer.editor)) {
-                  let editLayer = featureLayer.editor.editLayer;
-                  editTools.editLayer.removeLayer(editLayer);
-                  editTools.featuresLayer.removeLayer(layer);
-                }
-              }
-            } else if (dirtyType === 'updated' || dirtyType === 'deleted') {
-              if (!Ember.isNone(layer)) {
-                if (!Ember.isNone(layer.editor)) {
-                  let editLayer = layer.editor.editLayer;
-                  editTools.editLayer.removeLayer(editLayer);
-                }
-
-                if (leafletObject.hasLayer(layer)) {
-                  leafletObject.removeLayer(layer);
-                }
-              }
-
-              model.rollbackAttributes();
-              delete leafletObject.models[index];
-              featuresIds.push(model.get('id'));
             }
-          }
-        });
 
-      if (!Ember.isNone(ids)) {
-        ids.forEach((id) => {
-          delete leafletObject.models[id];
-        });
-      } else {
-        editTools.editLayer.clearLayers();
-      }
+            model.rollbackAttributes();
+            delete leafletObject.models[index];
+            featuresIds.push(model.get('id'));
+          }
+        }
+      });
+
+    if (!Ember.isNone(ids)) {
+      ids.forEach((id) => {
+        delete leafletObject.models[id];
+      });
+    } else {
+      editTools.editLayer.clearLayers();
     }
 
     return featuresIds;

--- a/addon/components/layers/tile-vector-layer.js
+++ b/addon/components/layers/tile-vector-layer.js
@@ -6,6 +6,8 @@ export default BaseVectorLayer.extend({
     'url',
     'layerName',
     'style',
+    'minZoom',
+    'maxZoom'
   ],
 
   /**
@@ -19,7 +21,9 @@ export default BaseVectorLayer.extend({
     let nameLayer = options.layerName;
     let url = options.url;
     let vectorGridOptions = {
-      vectorTileLayerStyles: {}
+      vectorTileLayerStyles: {},
+      maxZoom: options.maxZoom,
+      minZoom: options.minZoom
     };
     vectorGridOptions.vectorTileLayerStyles[nameLayer] = options.style;
     return L.vectorGrid.protobuf(url, vectorGridOptions);

--- a/addon/components/layers/wms-wfs-layer.js
+++ b/addon/components/layers/wms-wfs-layer.js
@@ -59,6 +59,7 @@ export default WmsLayerComponent.extend({
       this.get('_wfsLayer._leafletObject').showLayerObjects = true;
       return this.get('_wfsLayer').continueLoad(this.get('_wfsLayer._leafletObject'));
     }).then(() => {
+      Ember.set(resultingAttributesOptions, 'objectFirst', resultingAttributesOptions.object);
       Ember.set(resultingAttributesOptions, 'object', this.get('_wfsLayer._leafletObject'));
       Ember.set(resultingAttributesOptions, 'settings.readonly', this.get('wfs.readonly'));
 

--- a/addon/components/legends/wms-legend.js
+++ b/addon/components/legends/wms-legend.js
@@ -109,7 +109,7 @@ export default BaseLegendComponent.extend({
                       parameters.height = legendImageScale;
                       legendsContainer.push({
                         src: `${url}${L.Util.getParamString(parameters)}`,
-                        layerName: rule.name,
+                        layerName: rule.title || rule.name,
                         useLayerName: true,
                         style: `height: ${this.get('height')}px;`
                       });

--- a/addon/components/map-commands-dialogs/export.js
+++ b/addon/components/map-commands-dialogs/export.js
@@ -397,7 +397,7 @@ let FlexberryExportMapCommandDialogComponent = Ember.Component.extend({
           let startIndex = 0;
           let count = 2;
           while (legendReduce.length > 0) {
-            let lastVisibleIndex = legendReduce.filter((l) => _this.isElementFullyVisibleInContainer(l, legendCopyContainer[0])).length - 1;
+            let lastVisibleIndex = legendReduce.filter((l) => _this.isElementFullyVisibleInContainer(l, legendCopyContainer[0], mapPadding)).length - 1;
             additionalPages.pushObject({
               index: count,
               start: startIndex,
@@ -605,7 +605,7 @@ let FlexberryExportMapCommandDialogComponent = Ember.Component.extend({
    * Style is needed to be copied while exporting
    * Also needed to rewrite deep children
    */
-  legendCustomStyle: Ember.computed('', function() {
+  legendCustomStyle: Ember.computed('', function () {
     return Ember.String.htmlSafe(`<style>
     .flexberry-export-map-command-dialog-legend-control-map .layer-legend {
       display: block !important;
@@ -929,7 +929,7 @@ let FlexberryExportMapCommandDialogComponent = Ember.Component.extend({
   /**
    * Observe map display mod and turn off legend
    */
-  mapOnlyModeObserver: Ember.observer('_options.displayMode', function() {
+  mapOnlyModeObserver: Ember.observer('_options.displayMode', function () {
     if (this.get('_options.displayMode') === 'map-only-mode') {
       this.set('_options.legendControl', false);
       this.set('_options.scaleControl', false);
@@ -1081,27 +1081,25 @@ let FlexberryExportMapCommandDialogComponent = Ember.Component.extend({
           });
 
           let firstInvisibleIndex = legends.length;
-          legends.each(function(l) {
+          legends.each(function (l) {
             if (!_this.isElementFullyVisibleInContainer(legends[l], container, padding) && l < firstInvisibleIndex) {
               firstInvisibleIndex = l;
             }
           });
           let lastVisible = (firstInvisibleIndex > 0 && firstInvisibleIndex < legends.length) ? legends[firstInvisibleIndex - 1] : null;
-          let invisibleLegends = legends.filter((l) => !_this.isElementFullyVisibleInContainer(legends[l], container));
+          let invisibleLegends = legends.filter((l) => !_this.isElementFullyVisibleInContainer(legends[l], container, padding));
           if (_this.get('_options.legendUnderMap')) {
             if (!Ember.$('label#export-legend-more').length && invisibleLegends.length) {
               if (!lastVisible) {
                 Ember.$('.flexberry-export-map-command-dialog-legend-control-map', container).prepend('<label id="export-legend-more">...</label>');
               } else {
-                Ember.$('.layer-legend-image-wrapper:not(.layer-caption)', lastVisible).append('<label id="export-legend-more">...</label>');
+                Ember.$('.legend-container', lastVisible).append('<label id="export-legend-more">...</label>');
               }
             } else if (!invisibleLegends.length) {
               Ember.$('label#export-legend-more').remove();
             }
 
-            for (let i = firstInvisibleIndex; i < legends.length; i++) {
-              Ember.$(legends[i]).css('visibility', 'hidden');
-            }
+            invisibleLegends.css('visibility', 'hidden')
           }
 
           Ember.run.later(() => { _this.set('isBusy', false); }, 0);
@@ -1141,6 +1139,14 @@ let FlexberryExportMapCommandDialogComponent = Ember.Component.extend({
     const elementSettings = element.getBoundingClientRect();
     const containerSettings = container.getBoundingClientRect();
     let padding = (bottomPadding) ? bottomPadding : 0;
+    console.log({
+      container, element, padding, containerBounding: container.getBoundingClientRect(), elementBounding: element.getBoundingClientRect(), isVisible: (
+        (elementSettings.left > containerSettings.left) &&
+        (elementSettings.top > containerSettings.top) &&
+        (elementSettings.right < containerSettings.right) &&
+        (elementSettings.bottom < (containerSettings.bottom - padding))
+      )
+    })
     return (
       (elementSettings.left > containerSettings.left) &&
       (elementSettings.top > containerSettings.top) &&
@@ -1555,7 +1561,7 @@ let FlexberryExportMapCommandDialogComponent = Ember.Component.extend({
       if (additionalPageNumber >= 0) {
         let indexes = this.get('additionalPages')[additionalPageNumber];
         let legends = Ember.$('.ember-view.layer-legend', this.get('_$sheetOfLegend'));
-        legends.each(function() {
+        legends.each(function () {
           Ember.$(this).css('visibility', 'hidden');
           Ember.$(this).css('position', 'absolute');
         });
@@ -2167,7 +2173,7 @@ let FlexberryExportMapCommandDialogComponent = Ember.Component.extend({
           'column-fill': 'auto',
           'column-gap': `${this.get('mapPadding')}px`
         });
-        Ember.$('.layer-legend', $sheetOfPaper).each(function() {
+        Ember.$('.layer-legend', $sheetOfPaper).each(function () {
           Ember.$(this).css('visibility', 'visible');
           Ember.$(this).css('position', 'relative');
         });
@@ -2242,7 +2248,7 @@ let FlexberryExportMapCommandDialogComponent = Ember.Component.extend({
       if (options.additionalPageNumber >= 0) {
         let indexes = this.get('additionalPages')[options.additionalPageNumber];
         let legends = Ember.$('.ember-view.layer-legend', $sheetOfLegend);
-        legends.each(function() {
+        legends.each(function () {
           Ember.$(this).css('visibility', 'hidden');
           Ember.$(this).css('position', 'absolute');
         });

--- a/addon/components/map-commands-dialogs/export.js
+++ b/addon/components/map-commands-dialogs/export.js
@@ -1056,96 +1056,78 @@ let FlexberryExportMapCommandDialogComponent = Ember.Component.extend({
     '_mapLegendPreviewHeight',
     '_mapHeightDelta',
     '_options.legendControl',
-    function() {
-      const sheetOfPaperPreviewHeight = this.get('_sheetOfPaperPreviewHeight');
-      const mapCaptionPreviewHeight = this.get('_mapCaptionPreviewHeight');
-
+    function () {
+      let sheetOfPaperPreviewHeight = this.get('_sheetOfPaperPreviewHeight');
+      let mapCaptionPreviewHeight = this.get('_mapCaptionPreviewHeight');
       if (Ember.isNone(sheetOfPaperPreviewHeight) || Ember.isNone(mapCaptionPreviewHeight)) {
-        return Ember.String.htmlSafe('');
+        return Ember.String.htmlSafe(``);
       }
 
-      const padding = this.get('mapPadding') * this.get('_sheetOfPaperPreviewScaleFactor');
+      const padding = (this.get('mapPadding') * this.get('_sheetOfPaperPreviewScaleFactor'));
 
-      // Schedule map size invalidation after render
-      Ember.run.scheduleOnce('afterRender', this, this._invalidateSizeOfLeafletMap);
+      // Real map size has been changed, so we need to refresh it's size after render, otherwise it may be displayed incorrectly.
+      Ember.run.scheduleOnce('afterRender', () => {
+        this._invalidateSizeOfLeafletMap();
 
-      this._handleLegendVisibility(padding);
+        // Logic for understand are there any invisible layers (should add '...'?)
+        let container = Ember.$('.flexberry-export-map-command-dialog-sheet-of-paper')[0];
+        let _this = this;
+        this.set('isBusy', true);
+
+        Ember.$(container).waitForImages(() => {
+          let legends = Ember.$('.ember-view.layer-legend', container);
+          legends.each(function () {
+            Ember.$(this).css('visibility', 'visible');
+          });
+
+          let firstInvisibleIndex = legends.length;
+          legends.each(function(l) {
+            if (!_this.isElementFullyVisibleInContainer(legends[l], container, padding) && l < firstInvisibleIndex) {
+              firstInvisibleIndex = l;
+            }
+          });
+          let lastVisible = (firstInvisibleIndex > 0 && firstInvisibleIndex < legends.length) ? legends[firstInvisibleIndex - 1] : null;
+          let invisibleLegends = legends.filter((l) => !_this.isElementFullyVisibleInContainer(legends[l], container));
+          if (_this.get('_options.legendUnderMap')) {
+            if (!Ember.$('label#export-legend-more').length && invisibleLegends.length) {
+              if (!lastVisible) {
+                Ember.$('.flexberry-export-map-command-dialog-legend-control-map', container).prepend('<label id="export-legend-more">...</label>');
+              } else {
+                Ember.$('.layer-legend-image-wrapper:not(.layer-caption)', lastVisible).append('<label id="export-legend-more">...</label>');
+              }
+            } else if (!invisibleLegends.length) {
+              Ember.$('label#export-legend-more').remove();
+            }
+
+            for (let i = firstInvisibleIndex; i < legends.length; i++) {
+              Ember.$(legends[i]).css('visibility', 'hidden');
+            }
+          }
+
+          Ember.run.later(() => { _this.set('isBusy', false); }, 0);
+        });
+      });
 
       if (this.get('_options.displayMode') === 'map-only-mode') {
-        return Ember.String.htmlSafe('height: 100%;');
+        return Ember.String.htmlSafe(`height: 100%;`);
       }
 
-      let legendHeight = this._calculateLegendHeight(padding);
-      const mapCaptionHeight = Math.max(mapCaptionPreviewHeight, padding);
+      var legendHeight = this.get('_mapLegendPreviewHeight');
+      var legendLines = this.get('_mapLegendLines');
 
-      const pxHeightValue = sheetOfPaperPreviewHeight - mapCaptionHeight - legendHeight;
+      // 6 - is margin from css
+      legendHeight = (legendHeight + 6) * legendLines + padding + legendStyleConstants.heightMargin; // margin
+      if (!this.get('_options.legendUnderMap') || !this.get('_options.legendControl')) {
+        legendHeight = padding;
+      }
+
+      const mapCaptionHeight = mapCaptionPreviewHeight < padding ? padding : mapCaptionPreviewHeight;
+      let pxHeightValue = sheetOfPaperPreviewHeight - mapCaptionHeight -
+        legendHeight;
+
       return Ember.String.htmlSafe(`height: ${pxHeightValue}px; min-height: 60%;`);
     }
   ),
-
-  // Helper methods extracted for better readability
-  _handleLegendVisibility(padding) {
-    this.set('isBusy', true);
-    const container = Ember.$('.flexberry-export-map-command-dialog-sheet-of-paper')[0];
-    const _this = this;
-
-    Ember.$(container).waitForImages(() => {
-      const legends = Ember.$('.ember-view.layer-legend', container);
-
-      // Make all legends visible initially
-      legends.css('visibility', 'visible');
-
-      // Find first invisible legend
-      const firstInvisibleIndex = this._findFirstInvisibleLegend(legends, container, padding);
-      const lastVisible = firstInvisibleIndex > 0 ? legends[firstInvisibleIndex - 1] : null;
-      const invisibleLegends = legends.slice(firstInvisibleIndex);
-
-      if (this.get('_options.legendUnderMap')) {
-        this._updateLegendMoreLabel(invisibleLegends, lastVisible, container);
-        invisibleLegends.css('visibility', 'hidden');
-      }
-
-      Ember.run.later(() => {
-        this.set('isBusy', false);
-      }, 0);
-    });
-  },
-
-  _findFirstInvisibleLegend(legends, container, padding) {
-    for (let i = 0; i < legends.length; i++) {
-      if (!this.isElementFullyVisibleInContainer(legends[i], container, padding)) {
-        return i;
-      }
-    }
-    return legends.length;
-  },
-
-  _updateLegendMoreLabel(invisibleLegends, lastVisible, container) {
-    const moreLabelExists = Ember.$('label#export-legend-more').length > 0;
-
-    if (invisibleLegends.length) {
-      if (!moreLabelExists) {
-        const targetElement = lastVisible
-          ? Ember.$('.layer-legend-image-wrapper:not(.layer-caption)', lastVisible)
-          : Ember.$('.flexberry-export-map-command-dialog-legend-control-map', container);
-
-        targetElement.prepend('<label id="export-legend-more">...</label>');
-      }
-    } else if (moreLabelExists) {
-      Ember.$('label#export-legend-more').remove();
-    }
-  },
-
-  _calculateLegendHeight(padding) {
-    if (!this.get('_options.legendUnderMap') || !this.get('_options.legendControl')) {
-      return padding;
-    }
-
-    const legendHeight = this.get('_mapLegendPreviewHeight');
-    const legendLines = this.get('_mapLegendLines');
-    // 6 - is margin from css
-    return (legendHeight + 6) * legendLines + padding + legendStyleConstants.heightMargin;
-  },
 
   /**
    * Is element is visible in container.
@@ -1155,15 +1137,15 @@ let FlexberryExportMapCommandDialogComponent = Ember.Component.extend({
    * @param {Float} bottomPadding
    * @returns Boolean
    */
-  isElementFullyVisibleInContainer(element, container, bottomPadding = 0) {
-    const elementRect = element.getBoundingClientRect();
-    const containerRect = container.getBoundingClientRect();
-
+  isElementFullyVisibleInContainer(element, container, bottomPadding) {
+    const elementSettings = element.getBoundingClientRect();
+    const containerSettings = container.getBoundingClientRect();
+    let padding = (bottomPadding) ? bottomPadding : 0;
     return (
-      elementRect.left >= containerRect.left &&
-      elementRect.top >= containerRect.top &&
-      elementRect.right <= containerRect.right &&
-      elementRect.bottom <= (containerRect.bottom - bottomPadding)
+      (elementSettings.left > containerSettings.left) &&
+      (elementSettings.top > containerSettings.top) &&
+      (elementSettings.right < containerSettings.right) &&
+      (elementSettings.bottom < (containerSettings.bottom - padding))
     );
   },
 

--- a/addon/components/map-commands-dialogs/export.js
+++ b/addon/components/map-commands-dialogs/export.js
@@ -1056,78 +1056,96 @@ let FlexberryExportMapCommandDialogComponent = Ember.Component.extend({
     '_mapLegendPreviewHeight',
     '_mapHeightDelta',
     '_options.legendControl',
-    function () {
-      let sheetOfPaperPreviewHeight = this.get('_sheetOfPaperPreviewHeight');
-      let mapCaptionPreviewHeight = this.get('_mapCaptionPreviewHeight');
+    function() {
+      const sheetOfPaperPreviewHeight = this.get('_sheetOfPaperPreviewHeight');
+      const mapCaptionPreviewHeight = this.get('_mapCaptionPreviewHeight');
+
       if (Ember.isNone(sheetOfPaperPreviewHeight) || Ember.isNone(mapCaptionPreviewHeight)) {
-        return Ember.String.htmlSafe(``);
+        return Ember.String.htmlSafe('');
       }
 
-      const padding = (this.get('mapPadding') * this.get('_sheetOfPaperPreviewScaleFactor'));
+      const padding = this.get('mapPadding') * this.get('_sheetOfPaperPreviewScaleFactor');
 
-      // Real map size has been changed, so we need to refresh it's size after render, otherwise it may be displayed incorrectly.
-      Ember.run.scheduleOnce('afterRender', () => {
-        this._invalidateSizeOfLeafletMap();
+      // Schedule map size invalidation after render
+      Ember.run.scheduleOnce('afterRender', this, this._invalidateSizeOfLeafletMap);
 
-        // Logic for understand are there any invisible layers (should add '...'?)
-        let container = Ember.$('.flexberry-export-map-command-dialog-sheet-of-paper')[0];
-        let _this = this;
-        this.set('isBusy', true);
-
-        Ember.$(container).waitForImages(() => {
-          let legends = Ember.$('.ember-view.layer-legend', container);
-          legends.each(function () {
-            Ember.$(this).css('visibility', 'visible');
-          });
-
-          let firstInvisibleIndex = legends.length;
-          legends.each(function(l) {
-            if (!_this.isElementFullyVisibleInContainer(legends[l], container, padding) && l < firstInvisibleIndex) {
-              firstInvisibleIndex = l;
-            }
-          });
-          let lastVisible = (firstInvisibleIndex > 0 && firstInvisibleIndex < legends.length) ? legends[firstInvisibleIndex - 1] : null;
-          let invisibleLegends = legends.filter((l) => !_this.isElementFullyVisibleInContainer(legends[l], container));
-          if (_this.get('_options.legendUnderMap')) {
-            if (!Ember.$('label#export-legend-more').length && invisibleLegends.length) {
-              if (!lastVisible) {
-                Ember.$('.flexberry-export-map-command-dialog-legend-control-map', container).prepend('<label id="export-legend-more">...</label>');
-              } else {
-                Ember.$('.layer-legend-image-wrapper:not(.layer-caption)', lastVisible).append('<label id="export-legend-more">...</label>');
-              }
-            } else if (!invisibleLegends.length) {
-              Ember.$('label#export-legend-more').remove();
-            }
-
-            for (let i = firstInvisibleIndex; i < legends.length; i++) {
-              Ember.$(legends[i]).css('visibility', 'hidden');
-            }
-          }
-
-          Ember.run.later(() => { _this.set('isBusy', false); }, 0);
-        });
-      });
+      this._handleLegendVisibility(padding);
 
       if (this.get('_options.displayMode') === 'map-only-mode') {
-        return Ember.String.htmlSafe(`height: 100%;`);
+        return Ember.String.htmlSafe('height: 100%;');
       }
 
-      var legendHeight = this.get('_mapLegendPreviewHeight');
-      var legendLines = this.get('_mapLegendLines');
+      let legendHeight = this._calculateLegendHeight(padding);
+      const mapCaptionHeight = Math.max(mapCaptionPreviewHeight, padding);
 
-      // 6 - is margin from css
-      legendHeight = (legendHeight + 6) * legendLines + padding + legendStyleConstants.heightMargin; // margin
-      if (!this.get('_options.legendUnderMap') || !this.get('_options.legendControl')) {
-        legendHeight = padding;
-      }
-
-      const mapCaptionHeight = mapCaptionPreviewHeight < padding ? padding : mapCaptionPreviewHeight;
-      let pxHeightValue = sheetOfPaperPreviewHeight - mapCaptionHeight -
-        legendHeight;
-
+      const pxHeightValue = sheetOfPaperPreviewHeight - mapCaptionHeight - legendHeight;
       return Ember.String.htmlSafe(`height: ${pxHeightValue}px; min-height: 60%;`);
     }
   ),
+
+  // Helper methods extracted for better readability
+  _handleLegendVisibility(padding) {
+    this.set('isBusy', true);
+    const container = Ember.$('.flexberry-export-map-command-dialog-sheet-of-paper')[0];
+    const _this = this;
+
+    Ember.$(container).waitForImages(() => {
+      const legends = Ember.$('.ember-view.layer-legend', container);
+
+      // Make all legends visible initially
+      legends.css('visibility', 'visible');
+
+      // Find first invisible legend
+      const firstInvisibleIndex = this._findFirstInvisibleLegend(legends, container, padding);
+      const lastVisible = firstInvisibleIndex > 0 ? legends[firstInvisibleIndex - 1] : null;
+      const invisibleLegends = legends.slice(firstInvisibleIndex);
+
+      if (this.get('_options.legendUnderMap')) {
+        this._updateLegendMoreLabel(invisibleLegends, lastVisible, container);
+        invisibleLegends.css('visibility', 'hidden');
+      }
+
+      Ember.run.later(() => {
+        this.set('isBusy', false);
+      }, 0);
+    });
+  },
+
+  _findFirstInvisibleLegend(legends, container, padding) {
+    for (let i = 0; i < legends.length; i++) {
+      if (!this.isElementFullyVisibleInContainer(legends[i], container, padding)) {
+        return i;
+      }
+    }
+    return legends.length;
+  },
+
+  _updateLegendMoreLabel(invisibleLegends, lastVisible, container) {
+    const moreLabelExists = Ember.$('label#export-legend-more').length > 0;
+
+    if (invisibleLegends.length) {
+      if (!moreLabelExists) {
+        const targetElement = lastVisible
+          ? Ember.$('.layer-legend-image-wrapper:not(.layer-caption)', lastVisible)
+          : Ember.$('.flexberry-export-map-command-dialog-legend-control-map', container);
+
+        targetElement.prepend('<label id="export-legend-more">...</label>');
+      }
+    } else if (moreLabelExists) {
+      Ember.$('label#export-legend-more').remove();
+    }
+  },
+
+  _calculateLegendHeight(padding) {
+    if (!this.get('_options.legendUnderMap') || !this.get('_options.legendControl')) {
+      return padding;
+    }
+
+    const legendHeight = this.get('_mapLegendPreviewHeight');
+    const legendLines = this.get('_mapLegendLines');
+    // 6 - is margin from css
+    return (legendHeight + 6) * legendLines + padding + legendStyleConstants.heightMargin;
+  },
 
   /**
    * Is element is visible in container.
@@ -1137,15 +1155,15 @@ let FlexberryExportMapCommandDialogComponent = Ember.Component.extend({
    * @param {Float} bottomPadding
    * @returns Boolean
    */
-  isElementFullyVisibleInContainer(element, container, bottomPadding) {
-    const elementSettings = element.getBoundingClientRect();
-    const containerSettings = container.getBoundingClientRect();
-    let padding = (bottomPadding) ? bottomPadding : 0;
+  isElementFullyVisibleInContainer(element, container, bottomPadding = 0) {
+    const elementRect = element.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+
     return (
-      (elementSettings.left > containerSettings.left) &&
-      (elementSettings.top > containerSettings.top) &&
-      (elementSettings.right < containerSettings.right) &&
-      (elementSettings.bottom < (containerSettings.bottom - padding))
+      elementRect.left >= containerRect.left &&
+      elementRect.top >= containerRect.top &&
+      elementRect.right <= containerRect.right &&
+      elementRect.bottom <= (containerRect.bottom - bottomPadding)
     );
   },
 

--- a/addon/components/map-commands-dialogs/export.js
+++ b/addon/components/map-commands-dialogs/export.js
@@ -1099,7 +1099,7 @@ let FlexberryExportMapCommandDialogComponent = Ember.Component.extend({
               Ember.$('label#export-legend-more').remove();
             }
 
-            invisibleLegends.css('visibility', 'hidden')
+            invisibleLegends.css('visibility', 'hidden');
           }
 
           Ember.run.later(() => { _this.set('isBusy', false); }, 0);
@@ -1139,14 +1139,6 @@ let FlexberryExportMapCommandDialogComponent = Ember.Component.extend({
     const elementSettings = element.getBoundingClientRect();
     const containerSettings = container.getBoundingClientRect();
     let padding = (bottomPadding) ? bottomPadding : 0;
-    console.log({
-      container, element, padding, containerBounding: container.getBoundingClientRect(), elementBounding: element.getBoundingClientRect(), isVisible: (
-        (elementSettings.left > containerSettings.left) &&
-        (elementSettings.top > containerSettings.top) &&
-        (elementSettings.right < containerSettings.right) &&
-        (elementSettings.bottom < (containerSettings.bottom - padding))
-      )
-    })
     return (
       (elementSettings.left > containerSettings.left) &&
       (elementSettings.top > containerSettings.top) &&

--- a/addon/initializers/leaflet.js
+++ b/addon/initializers/leaflet.js
@@ -3,6 +3,7 @@
 */
 
 import { latLngToCoords, latLngsToCoords } from '../utils/lat-lng-to-coord';
+import Ember from 'ember';
 
 /**
   Registers options for leaflet library.
@@ -61,6 +62,12 @@ export function initialize(application, baseURL) {
   });
 
   L.LayerGroup.include({
+
+    // @method getLayerId(layer: Layer): Number
+    // Returns the internal ID for a layer
+    getLayerId: function (layer) {
+      return Ember.get(layer, 'feature.properties.primarykey') || L.Util.stamp(layer)
+    },
     toProjectedMultiPoint: function (crs, precision) {
       var coords = [];
 

--- a/addon/initializers/leaflet.js
+++ b/addon/initializers/leaflet.js
@@ -66,7 +66,7 @@ export function initialize(application, baseURL) {
     // @method getLayerId(layer: Layer): Number
     // Returns the internal ID for a layer
     getLayerId: function (layer) {
-      return Ember.get(layer, 'feature.properties.primarykey') || L.Util.stamp(layer)
+      return Ember.get(layer, 'feature.properties.primarykey') || L.Util.stamp(layer);
     },
     toProjectedMultiPoint: function (crs, precision) {
       var coords = [];

--- a/addon/styles/themes/default/modules/modal.overrides
+++ b/addon/styles/themes/default/modules/modal.overrides
@@ -217,10 +217,26 @@
       margin: 0;
       display: block;
       overflow: hidden;
+
+      .layer-legend > .legend-container {
+          display:flex;
+          flex-direction: column;
+      }
     }
     .flexberry-export-map-command-dialog-sheet-of-paper {
       .flexberry-export-map-command-dialog-legend-control-map {
         margin-top: 10px;
+      }
+
+       .layer-legend > .legend-container {
+          display:flex;
+          gap: 10px;
+
+          & > .layer-legend-caption {
+            //max-width: 250px;
+            //overflow: hidden;
+            //text-overflow: ellipsis;
+          }
       }
     }
 
@@ -232,9 +248,14 @@
         margin-bottom: 6px;
       }
       .layer-legend-image-wrapper {
-        float: left;
         height: inherit;
         padding-right: 11px;
+
+
+        & > .layer-legend-zoom {
+          display: flex;
+          align-items: center;
+        }
 
         .layer-legend-image {
           height: inherit;

--- a/addon/templates/components/geometry-add-modes/draw.hbs
+++ b/addon/templates/components/geometry-add-modes/draw.hbs
@@ -100,10 +100,13 @@
         </div>
       </div>
     </div>
-    <div class="offset-button flex-buttons">
-      <button type="submit" class="ui button positive" {{action "applyXY"}}>
-        {{t "components.geometry-add-modes.draw.movexy.apply"}}
-      </button>
+    <div class="flex-buttons">
+      {{flexberry-button
+        caption=(t "components.geometry-add-modes.draw.movexy.apply")
+        click=(action "applyXY")
+        class="primary"
+        readonly=(or _offsetInvalid.x _offsetInvalid.y)
+      }}
     </div>
   {{/if}}
 {{/if}}

--- a/addon/templates/components/legends/-private/vector-legend.hbs
+++ b/addon/templates/components/legends/-private/vector-legend.hbs
@@ -4,6 +4,7 @@
     legendSettings=layer.legendSettings
     showCaption=showLayerName
     caption=layer.name
+    class='legend-container'
     styleRules=layer.styleRules
   }}
 {{else}}

--- a/addon/templates/components/legends/layers-styles/-private/categorized.hbs
+++ b/addon/templates/components/legends/layers-styles/-private/categorized.hbs
@@ -2,7 +2,7 @@
   {{legends/layers-styles/simple
     styleSettings=category.styleSettings
     legendSettings=legendSettings
-    showCaption=true
+    showCaption=showCaption
     caption=category.name
   }}
 {{/each}}

--- a/addon/templates/components/legends/layers-styles/simple.hbs
+++ b/addon/templates/components/legends/layers-styles/simple.hbs
@@ -1,3 +1,6 @@
+{{#if showCaption}}
+  <label class="{{flexberryClassNames.caption}}" style="line-height: 1.3; vertical-align: top;">{{caption}}:</label>
+{{/if}}
 <div class="{{flexberryClassNames.imageWrapper}}">
   {{#if _geometriesCanBeDisplayed}}
     {{#if (and styleRules (gt styleRules.length 0))}}
@@ -9,9 +12,7 @@
       {{/each}}
     {{else}}
       <canvas class="{{flexberryClassNames.image}} geometries" width={{width}} height={{height}}></canvas>
-      {{#if showCaption}}
-        <label class="{{flexberryClassNames.caption}}" style="line-height: 1.3; vertical-align: top;">{{caption}}</label>
-      {{/if}}
+
     {{/if}}
   {{/if}}
   {{#if _markersCanBeDisplayed}}
@@ -40,9 +41,6 @@
           </div>
         </div>
       </div>
-      {{#if showCaption}}
-        <label class="{{flexberryClassNames.caption}}" style="line-height: 1.3; vertical-align: top;">{{caption}}</label>
-      {{/if}}
     {{/if}}
   {{/if}}
 

--- a/tests/unit/components/layers/odata-vector-layer-test.js
+++ b/tests/unit/components/layers/odata-vector-layer-test.js
@@ -1154,7 +1154,7 @@ test('test method clearChanges() with no changes', function(assert) {
       assert.equal(leafletMap.editTools.editLayer.getLayers().length, 1);
 
       component.clearChanges();
-      assert.equal(leafletMap.editTools.editLayer.getLayers().length, 1);
+      assert.equal(leafletMap.editTools.editLayer.getLayers().length, 0);
       done();
     });
   });

--- a/tests/unit/components/layers/odata-vector-layer-test.js
+++ b/tests/unit/components/layers/odata-vector-layer-test.js
@@ -402,14 +402,6 @@ var jsonModel = {
   external: false
 };
 
-let realCountArr = function (arr) {
-  return arr.filter((item) => {
-    if (item) {
-      return item;
-    }
-  }).length;
-};
-
 test('getFilterParameters return SimplePredicate on single value in array', function (assert) {
   assert.expect(2);
   var done = assert.async(1);
@@ -900,12 +892,12 @@ test('test method save() no modified objects', function(assert) {
       let obj = component.get('_adapterStoreModelProjectionGeom');
       let spyBatchUpdate = sinon.spy(obj.adapter, 'batchUpdate');
 
-      assert.equal(realCountArr(leafletObject.models), 0);
+      assert.equal(Object.values(leafletObject.models).length, 0);
       assert.equal(leafletObject.getLayers().length, 2);
 
       component.save();
 
-      assert.equal(realCountArr(leafletObject.models), 0);
+      assert.equal(Object.values(leafletObject.models).length, 0);
       assert.equal(leafletObject.getLayers().length, 2);
       assert.equal(spyBatchUpdate.callCount, 0);
 
@@ -927,7 +919,7 @@ test('test method save() with objects', function(assert) {
       let obj = component.get('_adapterStoreModelProjectionGeom');
       let spyBatchUpdate = sinon.spy(obj.adapter, 'batchUpdate');
 
-      assert.equal(realCountArr(leafletObject.models), 0);
+      assert.equal(Object.values(leafletObject.models).length, 0);
       assert.equal(leafletObject.getLayers().length, 2);
 
       let layerUpdate = leafletObject.getLayers()[0];
@@ -947,13 +939,13 @@ test('test method save() with objects', function(assert) {
           '7998208.303352221,6282204.143427601,7998205.77214398,6282035.717038031,7998313.982057768';
       assert.equal(layerUpdate.feature.geometry.coordinates.toString(), coordinates);
 
-      assert.equal(realCountArr(leafletObject.models), 1);
+      assert.equal(Object.values(leafletObject.models).length, 1);
       assert.equal(leafletObject.getLayers().length, 2);
 
       let layerRemove = leafletObject.getLayers()[1];
       leafletObject.removeLayer(layerRemove);
 
-      assert.equal(realCountArr(leafletObject.models), 2);
+      assert.equal(Object.values(leafletObject.models).length, 2);
       assert.equal(leafletObject.getLayers().length, 1);
 
       let feature = {
@@ -969,7 +961,7 @@ test('test method save() with objects', function(assert) {
       let pk = layerAdd.feature.properties.primarykey;
       responseBatchUpdate.replace('a5532858-dbdc-4d3c-9eaf-3d71d097ceb0', pk);
 
-      assert.equal(realCountArr(leafletObject.models), 3);
+      assert.equal(Object.values(leafletObject.models).length, 3);
       assert.equal(leafletObject.getLayers().length, 2);
 
       let mapModel = store.createRecord('new-platform-flexberry-g-i-s-map');
@@ -983,7 +975,7 @@ test('test method save() with objects', function(assert) {
         assert.equal(_getModelLayerFeatureStub.callCount, 1);
         assert.deepEqual(_getModelLayerFeatureStub.getCall(0).args[1], [pk]);
         assert.equal(data.layers.length, 1);
-        assert.equal(realCountArr(leafletObject.models), 0);
+        assert.equal(Object.values(leafletObject.models).length, 0);
         assert.equal(leafletObject.getLayers().length, 1);
         assert.equal(leafletObject._labelsLayer.getLayers().length, 1);
         assert.equal(leafletObject.getLayers()[0].state, 'exist');
@@ -1129,10 +1121,10 @@ test('test method clearLayers()', function(assert) {
     leafletLayer.promiseLoadLayer.then(() => {
       let leafletObject = component.get('_leafletObject');
 
-      assert.equal(realCountArr(leafletObject.models), 0);
+      assert.equal(Object.values(leafletObject.models).length, 0);
       assert.equal(leafletObject.getLayers().length, 2);
       leafletObject.clearLayers();
-      assert.equal(realCountArr(leafletObject.models), 0);
+      assert.equal(Object.values(leafletObject.models).length, 0);
       assert.equal(leafletObject.getLayers().length, 0);
       done();
     });
@@ -1150,14 +1142,14 @@ test('test method clearChanges() with no changes', function(assert) {
       let leafletObject = component.get('_leafletObject');
       let leafletMap = component.get('leafletMap');
 
-      assert.equal(realCountArr(leafletObject.models), 0);
+      assert.equal(Object.values(leafletObject.models).length, 0);
       assert.equal(leafletObject.getLayers().length, 2);
       assert.equal(leafletMap.editTools.editLayer.getLayers().length, 0);
 
       let layerUpdate = leafletObject.getLayers()[0];
       layerUpdate.enableEdit(leafletMap);
 
-      assert.equal(realCountArr(leafletObject.models), 0);
+      assert.equal(Object.values(leafletObject.models).length, 0);
       assert.equal(leafletObject.getLayers().length, 2);
       assert.equal(leafletMap.editTools.editLayer.getLayers().length, 1);
 
@@ -1179,7 +1171,7 @@ test('test method clearChanges() with create', function(assert) {
       let leafletObject = component.get('_leafletObject');
       let leafletMap = component.get('leafletMap');
 
-      assert.equal(realCountArr(leafletObject.models), 0);
+      assert.equal(Object.values(leafletObject.models).length, 0);
       assert.equal(leafletObject.getLayers().length, 2);
       assert.equal(leafletMap.editTools.editLayer.getLayers().length, 0);
 
@@ -1200,7 +1192,7 @@ test('test method clearChanges() with create', function(assert) {
       layerAdd.enableEdit(leafletMap);
       leafletMap.editTools.featuresLayer.addLayer(layerAdd);
 
-      assert.equal(realCountArr(leafletObject.models), 1);
+      assert.equal(Object.values(leafletObject.models).length, 1);
       assert.equal(leafletObject.getLayers().length, 3);
       assert.equal(leafletMap.editTools.editLayer.getLayers().length, 1);
       assert.equal(leafletMap.editTools.featuresLayer.getLayers().length, 1);
@@ -1224,7 +1216,7 @@ test('test method clearChanges() with update and delete', function(assert) {
       let leafletObject = component.get('_leafletObject');
       let leafletMap = component.get('leafletMap');
 
-      assert.equal(realCountArr(leafletObject.models), 0);
+      assert.equal(Object.values(leafletObject.models).length, 0);
       assert.equal(leafletObject.getLayers().length, 2);
       assert.equal(leafletMap.editTools.editLayer.getLayers().length, 0);
 
@@ -1233,7 +1225,7 @@ test('test method clearChanges() with update and delete', function(assert) {
       layerUpdate.enableEdit(leafletMap);
       leafletObject.editLayer(layerUpdate);
 
-      assert.equal(realCountArr(leafletObject.models), 1);
+      assert.equal(Object.values(leafletObject.models).length, 1);
       assert.equal(leafletObject.getLayers().length, 2);
       assert.equal(leafletMap.editTools.editLayer.getLayers().length, 1);
 
@@ -1241,7 +1233,7 @@ test('test method clearChanges() with update and delete', function(assert) {
       layerRemove.enableEdit(leafletMap);
       leafletObject.removeLayer(layerRemove);
 
-      assert.equal(realCountArr(leafletObject.models), 2);
+      assert.equal(Object.values(leafletObject.models).length, 2);
       assert.equal(leafletObject.getLayers().length, 1);
       assert.equal(leafletMap.editTools.editLayer.getLayers().length, 2);
 


### PR DESCRIPTION
## [Текущие ошибки версии 31.07.2025](https://gitlab.skyori.ru/rgis-perm/rgis-issues/-/issues/87)

## Готово
* Добавлена блокировка кнопки "применить" при невалидном смещении
* Расширен regex при валидации xy смещения
* Используется rule.title(sld `<caption>`) при отображении легенды по умолчанию вместо `<name>`
* Добавлено учитывание min/max zoom для tile-vector слоев
* Скрытие тайла wms-wfs слоя в режиме редактирования объекта
* Исправлен вывод легенды при экспорте карты
* Идентфикация объектов по словарю leaflet (layer.hasLayer) переписана на GUID из feature.properties.primarykey для векторных объектов по умолчанию вместо int L.Util.stamp()